### PR TITLE
feat: DBスキーマ変更（words・wordbook_wordテーブル）

### DIFF
--- a/backend/database/migrations/2026_07_01_000000_update_words_and_wordbook_word_schema.php
+++ b/backend/database/migrations/2026_07_01_000000_update_words_and_wordbook_word_schema.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('words', function (Blueprint $table) {
+            $table->dropColumn(['e_sentence', 'j_sentence']);
+            $table->enum('part_of_speech', ['名詞', '動詞', '形容詞', '副詞', '前置詞'])->after('japanese');
+        });
+
+        Schema::table('wordbook_word', function (Blueprint $table) {
+            $table->integer('order')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('wordbook_word', function (Blueprint $table) {
+            $table->integer('order')->nullable(false)->change();
+        });
+
+        Schema::table('words', function (Blueprint $table) {
+            $table->dropColumn('part_of_speech');
+            $table->string('e_sentence')->nullable();
+            $table->string('j_sentence')->nullable();
+        });
+    }
+};


### PR DESCRIPTION
## 概要

- Issue #6 として、単語管理・テスト機能改善に向けたDBスキーマ変更を実装

## 主な実装

- **Migration**：`words` テーブルから `e_sentence`・`j_sentence` を削除し、`part_of_speech`（enum: 名詞/動詞/形容詞/副詞/前置詞、NOT NULL）を `japanese` カラムの後ろに追加。`wordbook_word.order` をNULL許容に変更。`down()` で完全な逆操作を実装。

## 本PR対象外

- 既存単語データの品詞の自動設定（Issue #6 対象外）
- `Word` モデルの `$fillable` やリレーション変更（Issue #8 で対応）
- AdminController・FormRequest・Blade ビューの変更（Issue #7・#8・#9 で対応）
- Seeder の更新（Issue #8 で対応）

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] `e_sentence`・`j_sentence` カラムが `words` テーブルから削除されている
- [ ] `part_of_speech` カラムが `words` テーブルに追加されている（enum: 名詞/動詞/形容詞/副詞/前置詞、NOT NULL）
- [ ] `wordbook_word.order` カラムがNULL許容になっている
- [ ] Migrationが `up()` / `down()` ともに実装されている

Closes #6