### PR TITLE
feat: 単語帳選択ページの新設（Blade）

### DIFF
--- a/backend/app/Http/Controllers/AdminController.php
+++ b/backend/app/Http/Controllers/AdminController.php
@@ -34,6 +34,12 @@ class AdminController extends Controller
 		$word->wordbooks()->syncWithoutDetaching([$wordbookId => ['order' => $order]]);
 		return redirect()->route('list')->with('success', '単語帳への紐づけが変更されました');
 	}
+	public function selectWordbook()
+	{
+		$wordbooks = Wordbook::all();
+		return view('admin.select-wordbook', compact('wordbooks'));
+	}
+
 	public function create()
 	{
 		$wordbooks = Wordbook::all();
@@ -51,7 +57,7 @@ class AdminController extends Controller
 		$wordbookId = $request->input('wordbook_id');
 		$order = $request->input('order');
 		$word->wordbooks()->attach($wordbookId, ['order' => $order]);
-		return redirect()->route('create')->with('success', '単語を追加しました');
+		return redirect()->route('create', ['wordbook_id' => $wordbookId])->with('success', '単語を追加しました');
 	}
 	public function add()
 	{

--- a/backend/resources/views/admin/create.blade.php
+++ b/backend/resources/views/admin/create.blade.php
@@ -13,7 +13,7 @@
         <label for="wordbook">単語帳を選択：</label>
         <select name="wordbook_id" id="wordbook">
           @foreach ($wordbooks as $wordbook)
-            <option value="{{ $wordbook->id }}">{{ $wordbook->name }}</option>
+            <option value="{{ $wordbook->id }}" {{ request('wordbook_id') == $wordbook->id ? 'selected' : '' }}>{{ $wordbook->name }}</option>
           @endforeach
         </select>
       </div>

--- a/backend/resources/views/admin/select-wordbook.blade.php
+++ b/backend/resources/views/admin/select-wordbook.blade.php
@@ -1,0 +1,22 @@
+@extends('layouts.app')
+
+@section('css')
+  <link rel="stylesheet" href="{{ asset('css/index.css') }}" />
+@endsection
+
+@section('content')
+  <div class="container">
+    <h2>単語帳を選択</h2>
+    @if ($wordbooks->isEmpty())
+      <p>単語帳がありません。<a href="{{ route('add') }}">単語帳を追加する</a></p>
+    @else
+      <ul>
+        @foreach ($wordbooks as $wordbook)
+          <li>
+            <a href="{{ route('create', ['wordbook_id' => $wordbook->id]) }}">{{ $wordbook->name }}</a>
+          </li>
+        @endforeach
+      </ul>
+    @endif
+  </div>
+@endsection

--- a/backend/resources/views/layouts/app.blade.php
+++ b/backend/resources/views/layouts/app.blade.php
@@ -29,7 +29,7 @@
           @if (auth()->check())
           <li><a href="{{ route('test') }}">単語テスト</a></li>
           <li><a href="{{ route('list') }}">単語一覧</a></li>
-          <li><a href="{{ route('create') }}">単語の追加</a></li>
+          <li><a href="{{ route('create.wordbook') }}">単語の追加</a></li>
           <li><a href="{{ route('add') }}">単語帳の追加</a></li>
             <li>
               <form action="/logout" method="POST">

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -26,6 +26,7 @@ Route::middleware(['auth'])->group(function () {
   Route::get('/list', [AdminController::class, 'list'])->name('list');
   Route::get('/edit/{id}', [AdminController::class, 'edit'])->name('edit');
   Route::put('/edit/{id}', [AdminController::class, 'update'])->name('update');
+  Route::get('/create-wordbook', [AdminController::class, 'selectWordbook'])->name('create.wordbook');
   Route::get('/create', [AdminController::class, 'create'])->name('create');
   Route::post('/create', [AdminController::class, 'store'])->name('store');
   Route::get('/add', [AdminController::class, 'add'])->name('add');


### PR DESCRIPTION
## 概要

- Issue #7 として、単語追加前に登録先の単語帳を選択するページを Blade で実装
- 単語追加時に常に先頭の単語帳が選択されてしまう問題を解消

## 主な実装

- **`routes/web.php`**：auth グループ内に `GET /create-wordbook`（name: `create.wordbook`）を追加
- **`AdminController::selectWordbook()`**：全単語帳を取得して選択ページへ渡す新メソッドを追加
- **`admin/select-wordbook.blade.php`**（新規）：単語帳一覧をリスト表示。空の場合は「単語帳を追加する」へのリンクを表示
- **`admin/create.blade.php`**：`request('wordbook_id')` を使い、URLパラメータから選択済み単語帳を初期選択
- **`layouts/app.blade.php`**：ナビ「単語の追加」の遷移先を `route('create.wordbook')` に変更
- **`store()` リダイレクト修正**：単語追加成功後のリダイレクトに `wordbook_id` を引き継ぎ、連続追加時も選択状態を維持

## 承認済み方針との差異・補足

- `store()` のリダイレクト先に `wordbook_id` を引き継ぐ修正を追加（レビューで指摘、方針に明記はなかったが Issue #7 のスコープ内と判断）
- `select-wordbook.blade.php` に空状態の表示を追加（同じくレビュー指摘）

## 本PR対象外

- `AdminRequest` のバリデーション修正（`e-sentence` / `e_sentence` 名前不一致）→ Issue #8 で対応
- `store()` の削除済みカラム参照・`part_of_speech` 未設定 → Issue #8 で対応
- `edit()` / `update()` の `Word::find()` null 非ガード → 別 Issue で対応予定
- React SPA への移行 → Issue #18 で対応

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] 単語帳が2つ以上ある場合に、登録先の単語帳を自由に選択できるページが表示される
- [ ] 単語帳を選択後、その単語帳への単語追加フォームへ遷移できる
- [ ] 認証済みユーザーのみアクセスできる

### リグレッション確認

- [ ] 既存の `/create` への直接アクセスが引き続き機能する
- [ ] ナビ「単語一覧」「単語帳の追加」など他のリンクに影響がない

Closes #7