### PR TITLE
feat: 単語追加フォームに品詞選択を追加し英文・日本文欄を削除

### DIFF
--- a/backend/app/Http/Controllers/AdminController.php
+++ b/backend/app/Http/Controllers/AdminController.php
@@ -28,7 +28,7 @@ class AdminController extends Controller
 	public function update(AdminRequest $request, $id)
 	{
 		$word = Word::find($id);
-		$word->update($request->only(['english', 'japanese', 'e_sentence', 'j_sentence']));
+		$word->update($request->only(['english', 'japanese', 'part_of_speech']));
 		$wordbookId = $request->input('wordbook_id');
 		$order = $request->input('order');
 		$word->wordbooks()->syncWithoutDetaching([$wordbookId => ['order' => $order]]);
@@ -50,8 +50,7 @@ class AdminController extends Controller
 		$word = Word::firstOrCreate([
 			'english' => $request->english,
 			'japanese' => $request->japanese,
-			'e_sentence' => $request->e_sentence,
-			'j_sentence' => $request->j_sentence
+			'part_of_speech' => $request->part_of_speech,
 		]);
 		// 単語帳に単語を追加
 		$wordbookId = $request->input('wordbook_id');

--- a/backend/app/Http/Requests/AdminRequest.php
+++ b/backend/app/Http/Requests/AdminRequest.php
@@ -24,10 +24,9 @@ class AdminRequest extends FormRequest
 		return [
 			'english' => 'required|string|max:255',
 			'japanese' => 'required|string|max:255',
-			'e-sentence' => 'nullable|string|max:255',
-			'j-sentence' => 'nullable|string|max:255',
+			'part_of_speech' => 'required|in:名詞,動詞,形容詞,副詞,前置詞',
 			'wordbook_id' => 'required|integer|exists:wordbooks,id',
-			'order' => 'required|integer|min:1',
+			'order' => 'nullable|integer|min:1',
 		];
 	}
 
@@ -36,8 +35,8 @@ class AdminRequest extends FormRequest
 		return [
 			'english.required' => '英単語は必須です。',
 			'japanese.required' => '日本語訳は必須です。',
+			'part_of_speech.required' => '品詞の選択は必須です。',
 			'wordbook_id.required' => '単語帳の選択は必須です。',
-			'order.required' => '順序は必須です。',
 			'order.min' => '順序は1以上である必要があります。',
 		];
 	}

--- a/backend/app/Models/Word.php
+++ b/backend/app/Models/Word.php
@@ -12,8 +12,7 @@ class Word extends Model
 	protected $fillable = [
 		'english',
 		'japanese',
-		'e-sentence',
-		'j-sentence',
+		'part_of_speech',
 	];
 
 	public function wordbooks()

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -24,7 +24,8 @@ class DatabaseSeeder extends Seeder
       ]);
       Word::create([
         'english' => 'change',
-        'japanese' => 'を変える'
+        'japanese' => 'を変える',
+        'part_of_speech' => '動詞'
       ]);
     }
 }

--- a/backend/resources/views/admin/create.blade.php
+++ b/backend/resources/views/admin/create.blade.php
@@ -19,7 +19,7 @@
       </div>
       <div class="inner__text">
         <label for="order">Order:</label>
-        <input type="number" name="order" id="order" required>
+        <input type="number" name="order" id="order">
       </div>
       <div class="inner__text">
         <label for="english">英単語</label>
@@ -30,12 +30,17 @@
         <input type="text" name="japanese" id="japanese" required>
       </div>
       <div class="inner__text">
-        <label for="e_sentence">英文　</label>
-        <input type="text" name="e_sentence" id="e_sentence">
-      </div>
-      <div class="inner__text">
-        <label for="j_sentence">日本文</label>
-        <input type="text" name="j_sentence" id="j_sentence">
+        <span>品詞：</span>
+        <label for="part_of_speech_noun">名詞</label>
+        <input type="radio" name="part_of_speech" id="part_of_speech_noun" value="名詞" required>
+        <label for="part_of_speech_verb">動詞</label>
+        <input type="radio" name="part_of_speech" id="part_of_speech_verb" value="動詞" required>
+        <label for="part_of_speech_adjective">形容詞</label>
+        <input type="radio" name="part_of_speech" id="part_of_speech_adjective" value="形容詞" required>
+        <label for="part_of_speech_adverb">副詞</label>
+        <input type="radio" name="part_of_speech" id="part_of_speech_adverb" value="副詞" required>
+        <label for="part_of_speech_preposition">前置詞</label>
+        <input type="radio" name="part_of_speech" id="part_of_speech_preposition" value="前置詞" required>
       </div>
       <div class="test__inner">
         <button type="submit">追加</button>

--- a/backend/resources/views/admin/edit.blade.php
+++ b/backend/resources/views/admin/edit.blade.php
@@ -22,7 +22,7 @@
       </div>
       <div class="inner__text">
         <label for="order">Order:</label>
-        <input type="number" name="order" id="order" value="{{ old('order', $currentOrder) }}" required>
+        <input type="number" name="order" id="order" value="{{ old('order', $currentOrder) }}">
       </div>
       <!-- 単語の詳細情報 -->
       <div class="inner__text">
@@ -34,12 +34,17 @@
         <input type="text" name="japanese" id="japanese" value="{{ $word->japanese }}" required>
       </div>
       <div class="inner__text">
-        <label for="e_sentence">英文　</label>
-        <input type="text" name="e_sentence" id="e_sentence" value="{{ $word->e_sentence }}">
-      </div>
-      <div class="inner__text">
-        <label for="j_sentence">日本文</label>
-        <input type="text" name="j_sentence" id="j_sentence" value="{{ $word->j_sentence }}">
+        <span>品詞：</span>
+        <label for="part_of_speech_noun">名詞</label>
+        <input type="radio" name="part_of_speech" id="part_of_speech_noun" value="名詞" {{ $word->part_of_speech == '名詞' ? 'checked' : '' }} required>
+        <label for="part_of_speech_verb">動詞</label>
+        <input type="radio" name="part_of_speech" id="part_of_speech_verb" value="動詞" {{ $word->part_of_speech == '動詞' ? 'checked' : '' }} required>
+        <label for="part_of_speech_adjective">形容詞</label>
+        <input type="radio" name="part_of_speech" id="part_of_speech_adjective" value="形容詞" {{ $word->part_of_speech == '形容詞' ? 'checked' : '' }} required>
+        <label for="part_of_speech_adverb">副詞</label>
+        <input type="radio" name="part_of_speech" id="part_of_speech_adverb" value="副詞" {{ $word->part_of_speech == '副詞' ? 'checked' : '' }} required>
+        <label for="part_of_speech_preposition">前置詞</label>
+        <input type="radio" name="part_of_speech" id="part_of_speech_preposition" value="前置詞" {{ $word->part_of_speech == '前置詞' ? 'checked' : '' }} required>
       </div>
 
       <div class="test__inner">


### PR DESCRIPTION
## 概要

- Issue #8 として、単語追加・編集フォーム（Blade）から`e_sentence`（英文）・`j_sentence`（日本語文）の入力欄を削除し、品詞（`part_of_speech`）をラジオボタンで選択できるように変更

## 主な実装

- **`backend/app/Models/Word.php`**：`$fillable`から削除済みカラムに対応していた`'e-sentence'`・`'j-sentence'`を除去し、`'part_of_speech'`を追加
- **`backend/app/Http/Requests/AdminRequest.php`**：`part_of_speech`を`required|in:名詞,動詞,形容詞,副詞,前置詞`で必須化し、`order`を`nullable`に変更。不要になった`e-sentence`・`j-sentence`のルールを削除
- **`backend/app/Http/Controllers/AdminController.php`**：`store()`・`update()`の保存対象フィールドを`e_sentence`・`j_sentence`から`part_of_speech`に変更
- **`backend/resources/views/admin/create.blade.php` / `edit.blade.php`**：英文・日本文の入力欄を削除し、品詞のラジオボタン（名詞・動詞・形容詞・副詞・前置詞）を追加。`order`の`required`属性を削除。編集フォームでは既存の品詞を選択済み表示
- **`backend/database/seeders/DatabaseSeeder.php`**：`part_of_speech`がNOT NULLになったため、サンプル単語に`'動詞'`を追加（Issue #6の承認済み方針で本Issueへ対応を委譲）

## 本PR対象外

- 既存単語データの品詞の自動設定
- React SPAへの移行
- 単語一覧表示（`list.blade.php`）への品詞列追加

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] 単語追加フォームに`e_sentence`・`j_sentence`の入力欄がない
- [ ] 品詞をラジオボタンで選択できる
- [ ] 品詞を選択せずに送信するとバリデーションエラーになる
- [ ] `order`を空白のまま単語を登録できる
- [ ] 単語編集フォームにも同様の変更が反映されている

### リグレッション確認

- [ ] 既存機能への意図しない影響がない

Closes #8
