### PR TITLE
feat: テスト出題形式を単語帳選択・ランダムN問方式へ変更

### DIFF
--- a/backend/app/Http/Controllers/HomeController.php
+++ b/backend/app/Http/Controllers/HomeController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
 use App\Models\Word;
 use App\Models\Wordbook;
+use App\Http\Requests\TestRequest;
 
 class HomeController extends Controller
 {
@@ -15,23 +15,18 @@ class HomeController extends Controller
 		return view('index', compact('words', 'wordbooks'));
 	}
 
-	public function test(Request $request)
+	public function test()
 	{
-		$startId = $request->input('start_id');
-		$endId = $request->input('end_id');
-		$randomWords = Word::whereBetween('id', [$startId, $endId])->inRandomOrder()->limit(50)->get();
-		return view('test', compact('randomWords'));
+		$wordbooks = Wordbook::all();
+		return view('test', compact('wordbooks'));
 	}
 
-	public function startTest(Request $request)
+	public function startTest(TestRequest $request)
 	{
-		// 入力されたID範囲を取得
-		$startId = $request->input('start_id');
-		$endId = $request->input('end_id');
+		$wordbooks = Wordbook::all();
+		$wordbook = Wordbook::find($request->wordbook_id);
+		$words = $wordbook->words()->inRandomOrder()->limit($request->count)->get();
 
-		// データベースから指定範囲の単語を取得しランダムに並び替える
-		$words = Word::whereBetween('id', [$startId, $endId])->inRandomOrder()->limit(50)->get();
-
-		return view('test', compact('words', 'startId', 'endId'));
+		return view('test', compact('words', 'wordbook', 'wordbooks'));
 	}
 }

--- a/backend/app/Http/Requests/TestRequest.php
+++ b/backend/app/Http/Requests/TestRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TestRequest extends FormRequest
+{
+	/**
+	 * Determine if the user is authorized to make this request.
+	 */
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * Get the validation rules that apply to the request.
+	 *
+	 * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+	 */
+	public function rules(): array
+	{
+		return [
+			'wordbook_id' => 'required|integer|exists:wordbooks,id',
+			'count' => 'required|integer|min:1',
+		];
+	}
+
+	public function messages()
+	{
+		return [
+			'wordbook_id.required' => '単語帳の選択は必須です。',
+			'wordbook_id.exists' => '選択した単語帳が存在しません。',
+			'count.required' => '出題数の入力は必須です。',
+			'count.min' => '出題数は1以上である必要があります。',
+		];
+	}
+}

--- a/backend/resources/views/test.blade.php
+++ b/backend/resources/views/test.blade.php
@@ -10,20 +10,21 @@
     <form action="{{ route('test.start') }}" method="POST">
       @csrf
       <div class="test__inner">
-        <label for="start_id">No.</label>
-        <input type="number" name="start_id" id="start_id" required>
-        →
-        <label for="end_id">No.</label>
-        <input type="number" name="end_id" id="end_id" required>
+        <label for="wordbook_id">単語帳を選択：</label>
+        <select name="wordbook_id" id="wordbook_id">
+          @foreach ($wordbooks as $wordbookOption)
+            <option value="{{ $wordbookOption->id }}" {{ old('wordbook_id') == $wordbookOption->id ? 'selected' : '' }}>{{ $wordbookOption->name }}</option>
+          @endforeach
+        </select>
+        <label for="count">出題数</label>
+        <input type="number" name="count" id="count" value="{{ old('count', 20) }}" min="1" required>
         <button type="submit">テスト開始！</button>
       </div>
     </form>
 
     @isset($words)
       <div class="info__inner">
-        <p>単語の始まりのID: {{ $startId }}</p>
-        <p>→</p>
-        <p>単語の終わりのID: {{ $endId }}</p>
+        <p>単語帳: {{ $wordbook->name }}</p>
       </div>
       <div id="quiz">
         @foreach ($words as $index => $word)


### PR DESCRIPTION
## 概要

- Issue #9 として、テストの出題方式をID範囲指定からランダムN問方式へ変更

## 主な実装

- **`backend/app/Http/Requests/TestRequest.php`**：`wordbook_id`（存在するIDであること）と`count`（1以上の整数）を検証するFormRequestを新規作成
- **`backend/app/Http/Controllers/HomeController.php`**：`test()`は単語帳一覧を取得してビューへ渡すよう変更。`startTest()`はID範囲検索を廃止し、選択された単語帳に紐づく単語からランダムにN件取得するよう変更
- **`backend/resources/views/test.blade.php`**：`start_id`/`end_id`の数値入力を、単語帳選択の`<select>`と出題数`<input>`（デフォルト20）へ変更。結果表示部の単語帳名表示に対応

## 本PR対象外

- 品詞による絞り込み・フィルタ機能
- React SPAへの移行（別Issueで対応）

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] テスト開始時に単語帳と出題数を指定できる
- [ ] 指定した単語帳の中からランダムにN問出題される
- [ ] 出題数のデフォルトは20問である
- [ ] 未認証ユーザーもテストを利用できる

### リグレッション確認

- [ ] 既存機能への意図しない影響がない

Closes #9
