### PR TITLE
fix: 単語帳内の単語No（order）を必須に戻す

### DIFF
--- a/backend/app/Http/Requests/AdminRequest.php
+++ b/backend/app/Http/Requests/AdminRequest.php
@@ -26,7 +26,7 @@ class AdminRequest extends FormRequest
 			'japanese' => 'required|string|max:255',
 			'part_of_speech' => 'required|in:名詞,動詞,形容詞,副詞,前置詞',
 			'wordbook_id' => 'required|integer|exists:wordbooks,id',
-			'order' => 'nullable|integer|min:1',
+			'order' => 'required|integer|min:1',
 		];
 	}
 
@@ -37,6 +37,7 @@ class AdminRequest extends FormRequest
 			'japanese.required' => '日本語訳は必須です。',
 			'part_of_speech.required' => '品詞の選択は必須です。',
 			'wordbook_id.required' => '単語帳の選択は必須です。',
+			'order.required' => '順序は必須です。',
 			'order.min' => '順序は1以上である必要があります。',
 		];
 	}

--- a/backend/database/migrations/2026_07_02_140914_make_wordbook_word_order_required.php
+++ b/backend/database/migrations/2026_07_02_140914_make_wordbook_word_order_required.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('wordbook_word', function (Blueprint $table) {
+            $table->integer('order')->nullable(false)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('wordbook_word', function (Blueprint $table) {
+            $table->integer('order')->nullable()->change();
+        });
+    }
+};

--- a/backend/resources/views/admin/create.blade.php
+++ b/backend/resources/views/admin/create.blade.php
@@ -19,7 +19,7 @@
       </div>
       <div class="inner__text">
         <label for="order">Order:</label>
-        <input type="number" name="order" id="order">
+        <input type="number" name="order" id="order" required>
       </div>
       <div class="inner__text">
         <label for="english">英単語</label>

--- a/backend/resources/views/admin/edit.blade.php
+++ b/backend/resources/views/admin/edit.blade.php
@@ -22,7 +22,7 @@
       </div>
       <div class="inner__text">
         <label for="order">Order:</label>
-        <input type="number" name="order" id="order" value="{{ old('order', $currentOrder) }}">
+        <input type="number" name="order" id="order" value="{{ old('order', $currentOrder) }}" required>
       </div>
       <!-- 単語の詳細情報 -->
       <div class="inner__text">


### PR DESCRIPTION
## 概要

- Issue #27 として、`wordbook_word.order`を再度必須へ戻す
- Issue #6でNULL許容化、Issue #8でフォーム入力を任意化していたが、テスト機能（Issue #9）の実利用で`order`未設定の単語が正しく反映されない挙動が確認されたため

## 主な実装

- **`backend/database/migrations/2026_07_02_140914_make_wordbook_word_order_required.php`**：`wordbook_word.order`をNOT NULLへ戻す新規Migration（適用済みMigrationは書き換えず、`down()`と対称の内容で追加）
- **`backend/app/Http/Requests/AdminRequest.php`**：`order`のバリデーションを`nullable`から`required|integer|min:1`へ変更し、`order.required`メッセージを追加（Issue #8適用前の内容へ復元）
- **`backend/resources/views/admin/create.blade.php`・`backend/resources/views/admin/edit.blade.php`**：`order`入力欄に`required`属性を復元

## 本PR対象外

- Issue #9（テスト出題形式の変更）自体の変更

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] `wordbook_word.order`カラムがNOT NULLである
- [ ] 単語追加フォームで`order`を空欄のまま送信すると、バリデーションエラーになる
- [ ] 単語編集フォームで`order`を空欄のまま送信すると、バリデーションエラーになる
- [ ] Migration実行時、既存の`order`未設定レコードへの対応方針が明確になっている

### リグレッション確認

- [ ] 既存機能への意図しない影響がない

Closes #27
