### PR TITLE
refactor: AdminControllerの処理をUseCase・Repositoryへ分離

### DIFF
--- a/backend/app/Http/Controllers/AdminController.php
+++ b/backend/app/Http/Controllers/AdminController.php
@@ -2,60 +2,69 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
-use App\Models\Word;
-use App\Models\Wordbook;
 use App\Http\Requests\AdminRequest;
 use App\Http\Requests\WordbookRequest;
+use App\UseCases\Admin\CreateWordbookUseCase;
+use App\UseCases\Admin\CreateWordUseCase;
+use App\UseCases\Admin\ShowWordbookSelectionFormUseCase;
+use App\UseCases\Admin\ShowWordCreateFormUseCase;
+use App\UseCases\Admin\ShowWordEditFormUseCase;
+use App\UseCases\Admin\UpdateWordUseCase;
+use App\UseCases\Word\ListWordsUseCase;
 
 class AdminController extends Controller
 {
+	public function __construct(
+		private ListWordsUseCase $listWordsUseCase,
+		private ShowWordEditFormUseCase $showWordEditFormUseCase,
+		private UpdateWordUseCase $updateWordUseCase,
+		private ShowWordbookSelectionFormUseCase $showWordbookSelectionFormUseCase,
+		private ShowWordCreateFormUseCase $showWordCreateFormUseCase,
+		private CreateWordUseCase $createWordUseCase,
+		private CreateWordbookUseCase $createWordbookUseCase,
+	) {
+	}
+
 	public function list()
 	{
-		$words = Word::paginate(100);
-		$wordbooks = Wordbook::all();
-		return view('admin.list', compact('words', 'wordbooks'));
+		$data = $this->listWordsUseCase->execute();
+		return view('admin.list', $data);
 	}
 	public function edit($id)
 	{
-		$word = Word::find($id);
-		$wordbooks = Wordbook::all();
-		$currentWordbookId = $word->wordbooks->first() ? $word->wordbooks->first()->id : null;
-		$currentOrder = $word->wordbooks->first() ? $word->wordbooks->first()->pivot->order : null;
-		return view('admin.edit', compact('word', 'wordbooks', 'currentWordbookId', 'currentOrder'));
+		$data = $this->showWordEditFormUseCase->execute($id);
+		return view('admin.edit', $data);
 	}
 
 	public function update(AdminRequest $request, $id)
 	{
-		$word = Word::find($id);
-		$word->update($request->only(['english', 'japanese', 'part_of_speech']));
+		$wordData = $request->only(['english', 'japanese', 'part_of_speech']);
 		$wordbookId = $request->input('wordbook_id');
 		$order = $request->input('order');
-		$word->wordbooks()->syncWithoutDetaching([$wordbookId => ['order' => $order]]);
+		$this->updateWordUseCase->execute($id, $wordData, $wordbookId, $order);
 		return redirect()->route('list')->with('success', '単語帳への紐づけが変更されました');
 	}
 	public function selectWordbook()
 	{
-		$wordbooks = Wordbook::all();
-		return view('admin.select-wordbook', compact('wordbooks'));
+		$data = $this->showWordbookSelectionFormUseCase->execute();
+		return view('admin.select-wordbook', $data);
 	}
 
 	public function create()
 	{
-		$wordbooks = Wordbook::all();
-		return view('admin.create', compact('wordbooks'));
+		$data = $this->showWordCreateFormUseCase->execute();
+		return view('admin.create', $data);
 	}
 	public function store(AdminRequest $request)
 	{
-		$word = Word::firstOrCreate([
+		$wordData = [
 			'english' => $request->english,
 			'japanese' => $request->japanese,
 			'part_of_speech' => $request->part_of_speech,
-		]);
-		// 単語帳に単語を追加
+		];
 		$wordbookId = $request->input('wordbook_id');
 		$order = $request->input('order');
-		$word->wordbooks()->attach($wordbookId, ['order' => $order]);
+		$this->createWordUseCase->execute($wordData, $wordbookId, $order);
 		return redirect()->route('create', ['wordbook_id' => $wordbookId])->with('success', '単語を追加しました');
 	}
 	public function add()
@@ -64,7 +73,7 @@ class AdminController extends Controller
 	}
 	public function books(WordbookRequest $request)
 	{
-		Wordbook::create($request->all());
+		$this->createWordbookUseCase->execute($request->all());
 		return redirect()->route('list')->with('success', '単語帳を追加しました');
 	}
 }

--- a/backend/app/Interfaces/WordRepositoryInterface.php
+++ b/backend/app/Interfaces/WordRepositoryInterface.php
@@ -2,9 +2,20 @@
 
 namespace App\Interfaces;
 
+use App\Models\Word;
 use Illuminate\Pagination\LengthAwarePaginator;
 
 interface WordRepositoryInterface
 {
 	public function paginate(int $perPage): LengthAwarePaginator;
+
+	public function find(int $id): ?Word;
+
+	public function update(Word $word, array $data): Word;
+
+	public function firstOrCreate(array $attributes): Word;
+
+	public function attachWordbook(Word $word, int $wordbookId, int $order): void;
+
+	public function syncWordbookWithoutDetaching(Word $word, int $wordbookId, int $order): void;
 }

--- a/backend/app/Interfaces/WordbookRepositoryInterface.php
+++ b/backend/app/Interfaces/WordbookRepositoryInterface.php
@@ -12,4 +12,6 @@ interface WordbookRepositoryInterface
 	public function find(int $id): ?Wordbook;
 
 	public function getRandomWords(Wordbook $wordbook, int $count): Collection;
+
+	public function create(array $data): Wordbook;
 }

--- a/backend/app/Repositories/WordRepository.php
+++ b/backend/app/Repositories/WordRepository.php
@@ -12,4 +12,30 @@ class WordRepository implements WordRepositoryInterface
 	{
 		return Word::paginate($perPage);
 	}
+
+	public function find(int $id): ?Word
+	{
+		return Word::find($id);
+	}
+
+	public function update(Word $word, array $data): Word
+	{
+		$word->update($data);
+		return $word;
+	}
+
+	public function firstOrCreate(array $attributes): Word
+	{
+		return Word::firstOrCreate($attributes);
+	}
+
+	public function attachWordbook(Word $word, int $wordbookId, int $order): void
+	{
+		$word->wordbooks()->attach($wordbookId, ['order' => $order]);
+	}
+
+	public function syncWordbookWithoutDetaching(Word $word, int $wordbookId, int $order): void
+	{
+		$word->wordbooks()->syncWithoutDetaching([$wordbookId => ['order' => $order]]);
+	}
 }

--- a/backend/app/Repositories/WordbookRepository.php
+++ b/backend/app/Repositories/WordbookRepository.php
@@ -22,4 +22,9 @@ class WordbookRepository implements WordbookRepositoryInterface
 	{
 		return $wordbook->words()->inRandomOrder()->limit($count)->get();
 	}
+
+	public function create(array $data): Wordbook
+	{
+		return Wordbook::create($data);
+	}
 }

--- a/backend/app/UseCases/Admin/CreateWordUseCase.php
+++ b/backend/app/UseCases/Admin/CreateWordUseCase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\UseCases\Admin;
+
+use App\Interfaces\WordRepositoryInterface;
+
+class CreateWordUseCase
+{
+	public function __construct(
+		private WordRepositoryInterface $wordRepository,
+	) {
+	}
+
+	public function execute(array $wordData, int $wordbookId, int $order): void
+	{
+		$word = $this->wordRepository->firstOrCreate($wordData);
+		$this->wordRepository->attachWordbook($word, $wordbookId, $order);
+	}
+}

--- a/backend/app/UseCases/Admin/CreateWordbookUseCase.php
+++ b/backend/app/UseCases/Admin/CreateWordbookUseCase.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\UseCases\Admin;
+
+use App\Interfaces\WordbookRepositoryInterface;
+
+class CreateWordbookUseCase
+{
+	public function __construct(
+		private WordbookRepositoryInterface $wordbookRepository,
+	) {
+	}
+
+	public function execute(array $data): void
+	{
+		$this->wordbookRepository->create($data);
+	}
+}

--- a/backend/app/UseCases/Admin/ShowWordCreateFormUseCase.php
+++ b/backend/app/UseCases/Admin/ShowWordCreateFormUseCase.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\UseCases\Admin;
+
+use App\Interfaces\WordbookRepositoryInterface;
+
+class ShowWordCreateFormUseCase
+{
+	public function __construct(
+		private WordbookRepositoryInterface $wordbookRepository,
+	) {
+	}
+
+	public function execute(): array
+	{
+		return [
+			'wordbooks' => $this->wordbookRepository->all(),
+		];
+	}
+}

--- a/backend/app/UseCases/Admin/ShowWordEditFormUseCase.php
+++ b/backend/app/UseCases/Admin/ShowWordEditFormUseCase.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\UseCases\Admin;
+
+use App\Interfaces\WordRepositoryInterface;
+use App\Interfaces\WordbookRepositoryInterface;
+
+class ShowWordEditFormUseCase
+{
+	public function __construct(
+		private WordRepositoryInterface $wordRepository,
+		private WordbookRepositoryInterface $wordbookRepository,
+	) {
+	}
+
+	public function execute(int $id): array
+	{
+		$word = $this->wordRepository->find($id);
+		$wordbooks = $this->wordbookRepository->all();
+		$currentWordbookId = $word->wordbooks->first() ? $word->wordbooks->first()->id : null;
+		$currentOrder = $word->wordbooks->first() ? $word->wordbooks->first()->pivot->order : null;
+
+		return [
+			'word' => $word,
+			'wordbooks' => $wordbooks,
+			'currentWordbookId' => $currentWordbookId,
+			'currentOrder' => $currentOrder,
+		];
+	}
+}

--- a/backend/app/UseCases/Admin/ShowWordbookSelectionFormUseCase.php
+++ b/backend/app/UseCases/Admin/ShowWordbookSelectionFormUseCase.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\UseCases\Admin;
+
+use App\Interfaces\WordbookRepositoryInterface;
+
+class ShowWordbookSelectionFormUseCase
+{
+	public function __construct(
+		private WordbookRepositoryInterface $wordbookRepository,
+	) {
+	}
+
+	public function execute(): array
+	{
+		return [
+			'wordbooks' => $this->wordbookRepository->all(),
+		];
+	}
+}

--- a/backend/app/UseCases/Admin/UpdateWordUseCase.php
+++ b/backend/app/UseCases/Admin/UpdateWordUseCase.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\UseCases\Admin;
+
+use App\Interfaces\WordRepositoryInterface;
+
+class UpdateWordUseCase
+{
+	public function __construct(
+		private WordRepositoryInterface $wordRepository,
+	) {
+	}
+
+	public function execute(int $id, array $wordData, int $wordbookId, int $order): void
+	{
+		$word = $this->wordRepository->find($id);
+		$this->wordRepository->update($word, $wordData);
+		$this->wordRepository->syncWordbookWithoutDetaching($word, $wordbookId, $order);
+	}
+}


### PR DESCRIPTION
## 概要

- Issue #30 として、`AdminController`（`list`・`edit`・`update`・`selectWordbook`・`create`・`store`・`add`・`books`）のDB操作・業務処理をUseCase・Repositoryへ分離
- Issue #26（HomeController分）に続く、Controller単位分割の2件目
- `docs/decisions/usecase-repository-layer.md`の決定に基づき、Issue #26で作成済みの`WordRepositoryInterface`・`WordbookRepositoryInterface`・`AppServiceProvider`バインドを再利用・拡張

## 主な実装

- **`app/Interfaces/WordRepositoryInterface.php`**：`find`・`update`・`firstOrCreate`・`attachWordbook`・`syncWordbookWithoutDetaching`を追加
- **`app/Interfaces/WordbookRepositoryInterface.php`**：`create`を追加
- **`app/Repositories/WordRepository.php`**：上記5メソッドの実装（既存Eloquentクエリをそのまま移動）
- **`app/Repositories/WordbookRepository.php`**：`create`の実装（既存Eloquentクエリをそのまま移動）
- **`app/UseCases/Admin/ShowWordEditFormUseCase.php`**：`edit()`用、単語編集フォームの表示データを組み立て
- **`app/UseCases/Admin/UpdateWordUseCase.php`**：`update()`用、単語更新と単語帳紐づけ
- **`app/UseCases/Admin/ShowWordbookSelectionFormUseCase.php`**：`selectWordbook()`用、単語帳選択一覧の表示データ
- **`app/UseCases/Admin/ShowWordCreateFormUseCase.php`**：`create()`用、単語作成フォームの表示データ
- **`app/UseCases/Admin/CreateWordUseCase.php`**：`store()`用、単語作成と単語帳への紐づけ
- **`app/UseCases/Admin/CreateWordbookUseCase.php`**：`books()`用、単語帳作成
- **`app/Http/Controllers/AdminController.php`**：全メソッドをUseCase呼び出しとResponse返却のみへ変更

## 本PR対象外

- `HomeController`（Issue #26で対応済み）
- Service層・DTOの追加
- 新機能・画面の追加、既存の挙動変更
- Issue #10・#11（API化）の実装そのもの
- 自動テストの新規追加
- `add()`：DBアクセス・変数受け渡しがなく`admin/add.blade.php`も変数を参照しないため、UseCaseを介さず`view('admin.add')`をそのまま維持（承認済み方針どおり）

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）
- 変更・新規PHPファイルの構文チェック（`php -l`）のみ実施済み

### 受け入れ条件

- [x] AdminControllerの各メソッドが、UseCaseクラスの呼び出しとResponse返却のみで構成されている
- [x] DBへのクエリ（Word・Wordbookの取得・作成・更新）がRepositoryクラス内に集約されている
- [x] 必要なRepositoryInterfaceが定義され、UseCaseはInterface経由でRepositoryを利用している（配置先は Issue #26 決定済みの `app/Interfaces/` を踏襲）
- [x] RepositoryInterfaceと実装クラスのバインドが`AppServiceProvider`で行われている（Issue #26追加分を再利用、変更なし）
- [ ] リファクタリング前後で、単語一覧表示・単語編集・単語追加・単語帳追加の各画面が同じ挙動で動作する（ログイン後の実画面確認は未実施）

### リグレッション確認

- [ ] 既存機能への意図しない影響がない（`HomeController`側の画面確認は未実施）

Closes #30
