### PR TITLE
feat: API化：公開系エンドポイント（単語一覧・テスト）

### DIFF
--- a/backend/app/Http/Controllers/Api/TestController.php
+++ b/backend/app/Http/Controllers/Api/TestController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\TestRequest;
+use App\Http\Resources\WordbookResource;
+use App\Http\Resources\WordResource;
+use App\UseCases\Api\Test\StartTestUseCase;
+
+class TestController extends Controller
+{
+	public function __construct(
+		private StartTestUseCase $startTestUseCase,
+	) {
+	}
+
+	public function index(TestRequest $request)
+	{
+		$result = $this->startTestUseCase->execute($request->wordbook_id, $request->count);
+
+		return response()->json([
+			'data' => [
+				'wordbook' => new WordbookResource($result['wordbook']),
+				'words' => WordResource::collection($result['words']),
+			],
+		]);
+	}
+}

--- a/backend/app/Http/Controllers/Api/WordController.php
+++ b/backend/app/Http/Controllers/Api/WordController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\WordResource;
+use App\UseCases\Api\Word\ListWordsUseCase;
+
+class WordController extends Controller
+{
+	public function __construct(
+		private ListWordsUseCase $listWordsUseCase,
+	) {
+	}
+
+	public function index()
+	{
+		$words = $this->listWordsUseCase->execute();
+		return WordResource::collection($words);
+	}
+}

--- a/backend/app/Http/Controllers/Api/WordbookController.php
+++ b/backend/app/Http/Controllers/Api/WordbookController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\WordbookResource;
+use App\UseCases\Api\Wordbook\ListWordbooksUseCase;
+
+class WordbookController extends Controller
+{
+	public function __construct(
+		private ListWordbooksUseCase $listWordbooksUseCase,
+	) {
+	}
+
+	public function index()
+	{
+		$wordbooks = $this->listWordbooksUseCase->execute();
+		return WordbookResource::collection($wordbooks);
+	}
+}

--- a/backend/app/Http/Kernel.php
+++ b/backend/app/Http/Kernel.php
@@ -41,6 +41,7 @@ class Kernel extends HttpKernel
         'api' => [
             // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             // \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
+            \App\Http\Middleware\ForceJsonResponse::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
         ],
     ];

--- a/backend/app/Http/Middleware/ForceJsonResponse.php
+++ b/backend/app/Http/Middleware/ForceJsonResponse.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class ForceJsonResponse
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $request->headers->set('Accept', 'application/json');
+
+        return $next($request);
+    }
+}

--- a/backend/app/Http/Resources/WordResource.php
+++ b/backend/app/Http/Resources/WordResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class WordResource extends JsonResource
+{
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function toArray(Request $request): array
+	{
+		return [
+			'id' => $this->id,
+			'english' => $this->english,
+			'japanese' => $this->japanese,
+			'part_of_speech' => $this->part_of_speech,
+		];
+	}
+}

--- a/backend/app/Http/Resources/WordbookResource.php
+++ b/backend/app/Http/Resources/WordbookResource.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class WordbookResource extends JsonResource
+{
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function toArray(Request $request): array
+	{
+		return [
+			'id' => $this->id,
+			'name' => $this->name,
+		];
+	}
+}

--- a/backend/app/UseCases/Api/Test/StartTestUseCase.php
+++ b/backend/app/UseCases/Api/Test/StartTestUseCase.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\UseCases\Api\Test;
+
+use App\Interfaces\WordbookRepositoryInterface;
+
+class StartTestUseCase
+{
+	public function __construct(
+		private WordbookRepositoryInterface $wordbookRepository,
+	) {
+	}
+
+	public function execute(int $wordbookId, int $count): array
+	{
+		$wordbook = $this->wordbookRepository->find($wordbookId);
+		$words = $this->wordbookRepository->getRandomWords($wordbook, $count);
+
+		return [
+			'wordbook' => $wordbook,
+			'words' => $words,
+		];
+	}
+}

--- a/backend/app/UseCases/Api/Word/ListWordsUseCase.php
+++ b/backend/app/UseCases/Api/Word/ListWordsUseCase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\UseCases\Api\Word;
+
+use App\Interfaces\WordRepositoryInterface;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class ListWordsUseCase
+{
+	public function __construct(
+		private WordRepositoryInterface $wordRepository,
+	) {
+	}
+
+	public function execute(): LengthAwarePaginator
+	{
+		return $this->wordRepository->paginate(100);
+	}
+}

--- a/backend/app/UseCases/Api/Wordbook/ListWordbooksUseCase.php
+++ b/backend/app/UseCases/Api/Wordbook/ListWordbooksUseCase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\UseCases\Api\Wordbook;
+
+use App\Interfaces\WordbookRepositoryInterface;
+use Illuminate\Database\Eloquent\Collection;
+
+class ListWordbooksUseCase
+{
+	public function __construct(
+		private WordbookRepositoryInterface $wordbookRepository,
+	) {
+	}
+
+	public function execute(): Collection
+	{
+		return $this->wordbookRepository->all();
+	}
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Http\Controllers\Api\TestController;
+use App\Http\Controllers\Api\WordbookController;
+use App\Http\Controllers\Api\WordController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -17,3 +20,7 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::get('/words', [WordController::class, 'index'])->name('api.words.index');
+Route::get('/wordbooks', [WordbookController::class, 'index'])->name('api.wordbooks.index');
+Route::get('/test', [TestController::class, 'index'])->name('api.test.index');

--- a/docs/api/public-endpoints.md
+++ b/docs/api/public-endpoints.md
@@ -1,0 +1,111 @@
+# 公開系APIエンドポイント
+
+対象Issue: #10
+
+## 共通仕様
+
+- 認証：不要（未認証でアクセス可能）
+- レスポンスは`data`キーでラップする
+- 一覧は`Illuminate\Http\Resources\Json\JsonResource`のResourceクラスで整形する
+- ページネーションが発生する一覧は、Laravel標準のページネーション形式（`data` / `links` / `meta`）に従う
+- バリデーションエラーは`422`、Laravel標準のエラー形式（`message` / `errors`）で返す
+
+## GET /api/words
+
+単語一覧を取得する。
+
+### Request
+
+パラメータなし。
+
+### Response（200）
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "english": "apple",
+      "japanese": "りんご",
+      "part_of_speech": "名詞"
+    }
+  ],
+  "links": {
+    "first": "...",
+    "last": "...",
+    "prev": null,
+    "next": null
+  },
+  "meta": {
+    "current_page": 1,
+    "last_page": 1,
+    "per_page": 100,
+    "total": 1
+  }
+}
+```
+
+## GET /api/wordbooks
+
+単語帳一覧を取得する（テスト用の単語帳選択に使用）。
+
+### Request
+
+パラメータなし。
+
+### Response（200）
+
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "name": "TOEIC基礎"
+    }
+  ]
+}
+```
+
+## GET /api/test
+
+指定した単語帳・出題数に基づき、ランダムに出題する単語を取得する。
+
+### Request
+
+| パラメータ | 型 | 必須 | 説明 |
+|---|---|---|---|
+| `wordbook_id` | integer | 必須 | 出題対象の単語帳ID（`wordbooks`テーブルに存在すること） |
+| `count` | integer | 必須 | 出題数（1以上） |
+
+### Response（200）
+
+```json
+{
+  "data": {
+    "wordbook": {
+      "id": 1,
+      "name": "TOEIC基礎"
+    },
+    "words": [
+      {
+        "id": 1,
+        "english": "apple",
+        "japanese": "りんご",
+        "part_of_speech": "名詞"
+      }
+    ]
+  }
+}
+```
+
+### Response（422、バリデーションエラー）
+
+```json
+{
+  "message": "The wordbook id field is required. (and 1 more error)",
+  "errors": {
+    "wordbook_id": ["単語帳の選択は必須です。"],
+    "count": ["出題数の入力は必須です。"]
+  }
+}
+```


### PR DESCRIPTION
## 概要

- Issue #10 として、React SPAからデータ取得できる公開系APIエンドポイント（単語一覧・単語帳一覧・テスト問題取得）を実装

## 主な実装

- **`backend/app/Http/Controllers/Api/WordController.php`**：`GET /api/words` の受付。`ListWordsUseCase`（API用）を呼び出し、`WordResource::collection()`を返す
- **`backend/app/Http/Controllers/Api/WordbookController.php`**：`GET /api/wordbooks` の受付。`ListWordbooksUseCase`（API用）を呼び出し、`WordbookResource::collection()`を返す
- **`backend/app/Http/Controllers/Api/TestController.php`**：`GET /api/test` の受付。既存の`TestRequest`をそのまま再利用してバリデーションし、`StartTestUseCase`（API用）を呼び出して`wordbook`・`words`を`data`キーで返す
- **`backend/app/UseCases/Api/Word/ListWordsUseCase.php`**：`WordRepositoryInterface->paginate(100)`のみ実行。既存の`Word\ListWordsUseCase`はBlade専用（単語帳一覧も含む構成）のため転用せず新設
- **`backend/app/UseCases/Api/Wordbook/ListWordbooksUseCase.php`**：`WordbookRepositoryInterface->all()`のみ実行
- **`backend/app/UseCases/Api/Test/StartTestUseCase.php`**：`wordbookRepository->find()`・`getRandomWords()`のみ実行。既存の`Test\StartTestUseCase`はBladeの再描画用に単語帳全件取得を含むため、API用には不要なクエリとなり転用せず新設
- **`backend/app/Http/Resources/WordResource.php`**：`id, english, japanese, part_of_speech`を返す
- **`backend/app/Http/Resources/WordbookResource.php`**：`id, name`を返す
- **`backend/routes/api.php`**：`GET /api/words`・`GET /api/wordbooks`・`GET /api/test`を認証Middlewareなしで追加
- **`docs/api/public-endpoints.md`**：3エンドポイントのRequest/Response形式を記録し、受け入れ条件「`docs/api/`の仕様と一致」の正本とする

`WordRepository`・`WordbookRepository`・Interfaceは既存メソッドで充足するため変更なし。

## 本PR対象外

- 管理系エンドポイント（別Issue #11で対応）
- Reactページの実装（別Issueで対応）

## Test plan

### 自動チェック

- 未実施（テスト導入方針は未確定）

### 受け入れ条件

- [ ] `GET /api/words` で単語一覧をJSONで取得できる
- [ ] `GET /api/wordbooks` で単語帳一覧をJSONで取得できる
- [ ] `GET /api/test` で指定した単語帳・出題数に基づく問題をJSONで取得できる
- [ ] 上記エンドポイントは未認証でアクセスできる
- [ ] レスポンス形式が `docs/api/` の仕様と一致している

### リグレッション確認

- [ ] 既存機能（`/`・`/test`のBlade画面、`php artisan test`）への意図しない影響がない

Closes #10
