### PR TITLE
feat: 管理系APIエンドポイント（単語・単語帳CRUD）を追加

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/WordController.php
+++ b/backend/app/Http/Controllers/Api/Admin/WordController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\AdminRequest;
+use App\Http\Resources\WordResource;
+use App\Models\Word;
+use App\UseCases\Admin\CreateWordUseCase;
+use App\UseCases\Admin\DeleteWordUseCase;
+use App\UseCases\Admin\UpdateWordUseCase;
+use App\UseCases\Api\Word\ListWordsUseCase;
+
+class WordController extends Controller
+{
+	public function __construct(
+		private ListWordsUseCase $listWordsUseCase,
+		private CreateWordUseCase $createWordUseCase,
+		private UpdateWordUseCase $updateWordUseCase,
+		private DeleteWordUseCase $deleteWordUseCase,
+	) {
+	}
+
+	public function index()
+	{
+		$words = $this->listWordsUseCase->execute();
+		return WordResource::collection($words);
+	}
+
+	public function store(AdminRequest $request)
+	{
+		$wordData = [
+			'english' => $request->english,
+			'japanese' => $request->japanese,
+			'part_of_speech' => $request->part_of_speech,
+		];
+		$this->createWordUseCase->execute($wordData, $request->wordbook_id, $request->order);
+		return response()->noContent(201);
+	}
+
+	public function update(AdminRequest $request, Word $word)
+	{
+		$wordData = $request->only(['english', 'japanese', 'part_of_speech']);
+		$this->updateWordUseCase->execute($word->id, $wordData, $request->wordbook_id, $request->order);
+		return response()->noContent();
+	}
+
+	public function destroy(Word $word)
+	{
+		$this->deleteWordUseCase->execute($word->id);
+		return response()->noContent();
+	}
+}

--- a/backend/app/Http/Controllers/Api/Admin/WordbookController.php
+++ b/backend/app/Http/Controllers/Api/Admin/WordbookController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Api\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\WordbookRequest;
+use App\Http\Resources\WordbookResource;
+use App\UseCases\Admin\CreateWordbookUseCase;
+use App\UseCases\Api\Wordbook\ListWordbooksUseCase;
+
+class WordbookController extends Controller
+{
+	public function __construct(
+		private ListWordbooksUseCase $listWordbooksUseCase,
+		private CreateWordbookUseCase $createWordbookUseCase,
+	) {
+	}
+
+	public function index()
+	{
+		$wordbooks = $this->listWordbooksUseCase->execute();
+		return WordbookResource::collection($wordbooks);
+	}
+
+	public function store(WordbookRequest $request)
+	{
+		$this->createWordbookUseCase->execute($request->all());
+		return response()->noContent(201);
+	}
+}

--- a/backend/app/Interfaces/WordRepositoryInterface.php
+++ b/backend/app/Interfaces/WordRepositoryInterface.php
@@ -18,4 +18,6 @@ interface WordRepositoryInterface
 	public function attachWordbook(Word $word, int $wordbookId, int $order): void;
 
 	public function syncWordbookWithoutDetaching(Word $word, int $wordbookId, int $order): void;
+
+	public function delete(Word $word): void;
 }

--- a/backend/app/Repositories/WordRepository.php
+++ b/backend/app/Repositories/WordRepository.php
@@ -38,4 +38,9 @@ class WordRepository implements WordRepositoryInterface
 	{
 		$word->wordbooks()->syncWithoutDetaching([$wordbookId => ['order' => $order]]);
 	}
+
+	public function delete(Word $word): void
+	{
+		$word->delete();
+	}
 }

--- a/backend/app/UseCases/Admin/DeleteWordUseCase.php
+++ b/backend/app/UseCases/Admin/DeleteWordUseCase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\UseCases\Admin;
+
+use App\Interfaces\WordRepositoryInterface;
+
+class DeleteWordUseCase
+{
+	public function __construct(
+		private WordRepositoryInterface $wordRepository,
+	) {
+	}
+
+	public function execute(int $id): void
+	{
+		$word = $this->wordRepository->find($id);
+		$this->wordRepository->delete($word);
+	}
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Http\Controllers\Api\Admin\WordbookController as AdminWordbookController;
+use App\Http\Controllers\Api\Admin\WordController as AdminWordController;
 use App\Http\Controllers\Api\TestController;
 use App\Http\Controllers\Api\WordbookController;
 use App\Http\Controllers\Api\WordController;
@@ -24,3 +26,12 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 Route::get('/words', [WordController::class, 'index'])->name('api.words.index');
 Route::get('/wordbooks', [WordbookController::class, 'index'])->name('api.wordbooks.index');
 Route::get('/test', [TestController::class, 'index'])->name('api.test.index');
+
+Route::middleware('auth:sanctum')->prefix('admin')->name('api.admin.')->group(function () {
+    Route::get('/words', [AdminWordController::class, 'index'])->name('words.index');
+    Route::post('/words', [AdminWordController::class, 'store'])->name('words.store');
+    Route::put('/words/{word}', [AdminWordController::class, 'update'])->name('words.update');
+    Route::delete('/words/{word}', [AdminWordController::class, 'destroy'])->name('words.destroy');
+    Route::get('/wordbooks', [AdminWordbookController::class, 'index'])->name('wordbooks.index');
+    Route::post('/wordbooks', [AdminWordbookController::class, 'store'])->name('wordbooks.store');
+});


### PR DESCRIPTION
## 概要

- Issue #11 として、React SPAの管理ページ向けに認証付き管理系APIエンドポイントを実装

## 主な実装

- **`backend/routes/api.php`**：`auth:sanctum`ミドルウェア・`admin`プレフィックスのルートグループを追加し、単語・単語帳の管理系6エンドポイントを登録
- **`backend/app/Http/Controllers/Api/Admin/WordController.php`**：単語の一覧取得・作成・更新・削除。既存の`Api\Word\ListWordsUseCase`・`Admin\CreateWordUseCase`・`Admin\UpdateWordUseCase`を再利用し、HTTP層のみ新設
- **`backend/app/Http/Controllers/Api/Admin/WordbookController.php`**：単語帳の一覧取得・作成。既存の`Api\Wordbook\ListWordbooksUseCase`・`Admin\CreateWordbookUseCase`を再利用
- **`backend/app/UseCases/Admin/DeleteWordUseCase.php`**：単語削除用に新規追加（既存Blade管理画面には削除機能がなかったため）
- **`backend/app/Interfaces/WordRepositoryInterface.php`・`backend/app/Repositories/WordRepository.php`**：削除機能に対応する`delete()`を追加。`wordbook_word`の紐づけ削除はDBの`cascade`制約に委ね、追加処理は行っていない

## Figma / 設計書との差異・補足

- Issue本文の受け入れ条件「単語作成時に`order`がNULLで登録できる」は、本Issueより後に承認・実運用検証されたIssue #27（`wordbook_word.order`をNOT NULL・入力必須へ差し戻し）と矛盾するため、承認済み実装方針（Issueコメント）に基づき`order`は必須のまま実装した
- `docs/api/`に管理系APIの仕様書が存在しないため、公開系API（`docs/api/public-endpoints.md`）の共通仕様（Resourceによる整形、標準422形式）を管理系APIにも適用した
- `update`・`destroy`のレスポンスはボディを返さない`204`とし、新規作成の`store`（`201`）とは区別した。既存リソースを操作しボディを返さない点で`update`と`destroy`は統一している

## 本PR対象外

- 公開系エンドポイント（Issue #10で対応済み）
- Reactページの実装（Issue #17〜21で対応）
- Sanctum SPA連携設定（`EnsureFrontendRequestsAreStateful`・CORS等、Issue #22で対応）

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] 各エンドポイントが正しいHTTPステータスを返す
- [ ] 未認証でアクセスすると401が返る
- [ ] 単語作成時に `part_of_speech` が必須バリデーションされる
- [ ] 単語作成時に `order` がNULLで登録できる（Issue #27の決定により、本PRでは`order`必須として実装。人間の確認事項）
- [ ] レスポンス形式が `docs/api/` の仕様と一致している

### リグレッション確認

- [ ] 既存機能への意図しない影響がない（Blade管理画面・公開系API）

Closes #11
