### PR TITLE
feat: 共通ナビゲーションヘッダーの実装

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react-dom": "^19.2.7",
+        "react-router-dom": "^7.18.1"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.2",
@@ -1062,6 +1063,19 @@
         }
       }
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1552,6 +1566,44 @@
         "react": "^19.2.7"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
@@ -1590,6 +1642,12 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
     "node_modules/source-map-js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.2.7",
-    "react-dom": "^19.2.7"
+    "react-dom": "^19.2.7",
+    "react-router-dom": "^7.18.1"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.2",

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,29 @@
+import { Link } from 'react-router-dom'
+
+function Header() {
+  return (
+    <header className="border-b border-gray-200 bg-white">
+      <div className="mx-auto flex max-w-3xl items-center justify-between px-4 py-4">
+        <Link to="/" className="text-lg font-bold text-gray-900">
+          英単語テスト
+        </Link>
+        <nav>
+          <ul className="flex gap-6 text-sm font-medium">
+            <li>
+              <Link to="/" className="text-gray-700 hover:text-green-600">
+                単語一覧
+              </Link>
+            </li>
+            <li>
+              <Link to="/test" className="text-gray-700 hover:text-green-600">
+                単語テスト
+              </Link>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+  )
+}
+
+export default Header

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
## 概要

- Issue #37 として、React SPA全ページ（#15〜#21）で共通利用する、ナビゲーションヘッダーコンポーネントを実装
- ヘッダーのリンクをSPA内で機能させるため、本Issueの範囲拡張としてReact Router（react-router-dom）の導入・`BrowserRouter`設定もあわせて実施（承認済み実装方針に基づく）

## 主な実装

- **`frontend/package.json` / `frontend/package-lock.json`**：`react-router-dom`を依存関係へ追加
- **`frontend/src/main.tsx`**：`<App />`を`<BrowserRouter>`でラップし、SPA内ページ遷移の基盤を整備
- **`frontend/src/components/Header.tsx`**：共通ナビゲーションヘッダーを新規実装。`react-router-dom`の`Link`で「単語一覧」（`/`）・「単語テスト」（`/test`）へのリンクを提供。既存Blade（`web.php`の`index`/`test`ルート）のURLパスに合わせ、配色は`WordList.tsx`（#15）と同系統（白背景・緑系アクセント）でTailwindによりスタイリング

## 本PR対象外

- 各ページ本体（#15〜#21）へのHeader組み込み、および`App.tsx`への`<Routes>`/`<Route>`定義：各ページIssue側で対応
- 認証状態に応じたリンクの出し分け：#22（認証連携）で対応
- 管理系ページへのリンク：認証連携後に対応

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] 共通のヘッダー（ナビゲーション）コンポーネントが実装されている
- [ ] 単語一覧・単語テストへのリンクを含む
- [ ] Tailwind CSSでスタイリングされている
- [ ] react-router-domが導入され、BrowserRouterがアプリのルートに設定されている
- [ ] ヘッダーのリンクがReact Routerの`Link`で実装されている（ページ遷移時に画面全体がリロードされない）

### リグレッション確認

- [ ] 既存機能への意図しない影響がない

Closes #37
