### PR TITLE
feat: 単語テストページを追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { Route, Routes } from 'react-router-dom'
 import Header from './components/Header'
+import Test from './components/Test'
 import WordList from './components/WordList'
 import './App.css'
 
@@ -9,6 +10,7 @@ function App() {
       <Header />
       <Routes>
         <Route path="/" element={<WordList />} />
+        <Route path="/test" element={<Test />} />
       </Routes>
     </>
   )

--- a/frontend/src/api/test.ts
+++ b/frontend/src/api/test.ts
@@ -1,0 +1,16 @@
+import type { TestResponse } from '../types/test'
+
+export async function fetchTest(wordbookId: number, count: number): Promise<TestResponse> {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL
+  const params = new URLSearchParams({
+    wordbook_id: String(wordbookId),
+    count: String(count),
+  })
+  const res = await fetch(`${baseUrl}/test?${params.toString()}`)
+
+  if (!res.ok) {
+    throw new Error('テストの開始に失敗しました。')
+  }
+
+  return res.json() as Promise<TestResponse>
+}

--- a/frontend/src/api/wordbooks.ts
+++ b/frontend/src/api/wordbooks.ts
@@ -1,0 +1,12 @@
+import type { WordbookListResponse } from '../types/wordbook'
+
+export async function fetchWordbooks(): Promise<WordbookListResponse> {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL
+  const res = await fetch(`${baseUrl}/wordbooks`)
+
+  if (!res.ok) {
+    throw new Error('単語帳一覧の取得に失敗しました。')
+  }
+
+  return res.json() as Promise<WordbookListResponse>
+}

--- a/frontend/src/components/Test.tsx
+++ b/frontend/src/components/Test.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useState, type FormEvent } from 'react'
+import { fetchTest } from '../api/test'
+import { fetchWordbooks } from '../api/wordbooks'
+import type { Word } from '../types/word'
+import type { Wordbook } from '../types/wordbook'
+
+type Phase = 'form' | 'quiz' | 'result'
+
+function Test() {
+  const [wordbooks, setWordbooks] = useState<Wordbook[]>([])
+  const [wordbooksLoading, setWordbooksLoading] = useState(true)
+  const [wordbooksError, setWordbooksError] = useState<string | null>(null)
+
+  const [selectedWordbookId, setSelectedWordbookId] = useState<number | null>(null)
+  const [questionCount, setQuestionCount] = useState(20)
+
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const [phase, setPhase] = useState<Phase>('form')
+  const [testWordbook, setTestWordbook] = useState<Wordbook | null>(null)
+  const [words, setWords] = useState<Word[]>([])
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [showAnswer, setShowAnswer] = useState(false)
+  const [understoodCount, setUnderstoodCount] = useState(0)
+  const [notUnderstoodCount, setNotUnderstoodCount] = useState(0)
+
+  useEffect(() => {
+    let ignore = false
+
+    setWordbooksLoading(true)
+    setWordbooksError(null)
+
+    fetchWordbooks()
+      .then((response) => {
+        if (ignore) return
+        setWordbooks(response.data)
+        if (response.data.length > 0) {
+          setSelectedWordbookId(response.data[0].id)
+        }
+      })
+      .catch(() => {
+        if (ignore) return
+        setWordbooksError('単語帳一覧の取得に失敗しました。')
+      })
+      .finally(() => {
+        if (ignore) return
+        setWordbooksLoading(false)
+      })
+
+    return () => {
+      ignore = true
+    }
+  }, [])
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (selectedWordbookId === null || submitting) return
+
+    setSubmitting(true)
+    setSubmitError(null)
+
+    fetchTest(selectedWordbookId, questionCount)
+      .then((response) => {
+        setTestWordbook(response.data.wordbook)
+        setWords(response.data.words)
+        setCurrentIndex(0)
+        setShowAnswer(false)
+        setUnderstoodCount(0)
+        setNotUnderstoodCount(0)
+        setPhase('quiz')
+      })
+      .catch(() => {
+        setSubmitError('テストの開始に失敗しました。')
+      })
+      .finally(() => {
+        setSubmitting(false)
+      })
+  }
+
+  const handleJudge = (understood: boolean) => {
+    if (understood) {
+      setUnderstoodCount((prev) => prev + 1)
+    } else {
+      setNotUnderstoodCount((prev) => prev + 1)
+    }
+
+    if (currentIndex + 1 >= words.length) {
+      setPhase('result')
+      return
+    }
+
+    setCurrentIndex((prev) => prev + 1)
+    setShowAnswer(false)
+  }
+
+  const handleRestart = () => {
+    setPhase('form')
+    setSubmitError(null)
+  }
+
+  return (
+    <div className="min-h-screen bg-white px-4 py-10">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="mb-6 border-b-4 border-green-500 pb-2 text-3xl font-bold text-gray-900">単語テスト</h1>
+
+        {phase === 'form' && (
+          <>
+            {wordbooksLoading && <p className="text-gray-500">読み込み中...</p>}
+
+            {!wordbooksLoading && wordbooksError && (
+              <p role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+                {wordbooksError}
+              </p>
+            )}
+
+            {!wordbooksLoading && !wordbooksError && (
+              <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-gray-200 p-6 shadow-sm">
+                <div>
+                  <label htmlFor="wordbook_id" className="mb-1 block text-sm font-medium text-gray-700">
+                    単語帳を選択
+                  </label>
+                  <select
+                    id="wordbook_id"
+                    value={selectedWordbookId ?? ''}
+                    onChange={(event) => setSelectedWordbookId(Number(event.target.value))}
+                    required
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+                  >
+                    {wordbooks.map((wordbook) => (
+                      <option key={wordbook.id} value={wordbook.id}>
+                        {wordbook.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label htmlFor="count" className="mb-1 block text-sm font-medium text-gray-700">
+                    出題数
+                  </label>
+                  <input
+                    id="count"
+                    type="number"
+                    min={1}
+                    required
+                    value={questionCount}
+                    onChange={(event) => setQuestionCount(Number(event.target.value))}
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+                  />
+                </div>
+
+                {submitError && (
+                  <p role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+                    {submitError}
+                  </p>
+                )}
+
+                <button
+                  type="submit"
+                  disabled={submitting || selectedWordbookId === null}
+                  className="w-full rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
+                >
+                  {submitting ? '開始中...' : 'テスト開始！'}
+                </button>
+              </form>
+            )}
+          </>
+        )}
+
+        {phase === 'quiz' && words.length > 0 && (
+          <div className="rounded-lg border border-gray-200 p-6 shadow-sm">
+            {testWordbook && <p className="mb-4 text-sm text-gray-500">単語帳: {testWordbook.name}</p>}
+            <p className="mb-2 text-sm text-gray-500">
+              {currentIndex + 1} / {words.length}問
+            </p>
+
+            <div className="rounded-lg border border-gray-200 bg-green-50 px-6 py-10 text-center">
+              <p className="text-3xl font-bold text-gray-900">{words[currentIndex].english}</p>
+
+              {!showAnswer && (
+                <button
+                  type="button"
+                  onClick={() => setShowAnswer(true)}
+                  className="mt-6 rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
+                >
+                  答えを見る
+                </button>
+              )}
+
+              {showAnswer && (
+                <>
+                  <p className="mt-6 text-xl text-gray-700">{words[currentIndex].japanese}</p>
+                  <div className="mt-6 flex justify-center gap-4">
+                    <button
+                      type="button"
+                      onClick={() => handleJudge(true)}
+                      className="rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
+                    >
+                      理解した
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleJudge(false)}
+                      className="rounded-md bg-red-500 px-4 py-2 text-sm font-medium text-white hover:bg-red-600"
+                    >
+                      理解していない
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        )}
+
+        {phase === 'result' && (
+          <div className="rounded-lg border border-gray-200 p-6 shadow-sm">
+            <h2 className="mb-4 text-xl font-bold text-gray-900">理解度結果</h2>
+            {testWordbook && <p className="mb-4 text-sm text-gray-500">単語帳: {testWordbook.name}</p>}
+
+            <table className="w-full text-left text-sm">
+              <tbody className="divide-y divide-gray-100">
+                <tr>
+                  <th className="px-4 py-3 font-semibold text-gray-700">理解した単語数</th>
+                  <td className="px-4 py-3 text-gray-900">{understoodCount}</td>
+                </tr>
+                <tr>
+                  <th className="px-4 py-3 font-semibold text-gray-700">理解していない単語数</th>
+                  <td className="px-4 py-3 text-gray-900">{notUnderstoodCount}</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <button
+              type="button"
+              onClick={handleRestart}
+              className="mt-6 rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
+            >
+              もう一度テストする
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default Test

--- a/frontend/src/components/Test.tsx
+++ b/frontend/src/components/Test.tsx
@@ -62,6 +62,11 @@ function Test() {
 
     fetchTest(selectedWordbookId, questionCount)
       .then((response) => {
+        if (response.data.words.length === 0) {
+          setSubmitError('選択した単語帳に出題できる単語がありません。')
+          return
+        }
+
         setTestWordbook(response.data.wordbook)
         setWords(response.data.words)
         setCurrentIndex(0)

--- a/frontend/src/types/test.ts
+++ b/frontend/src/types/test.ts
@@ -1,0 +1,9 @@
+import type { Word } from './word'
+import type { Wordbook } from './wordbook'
+
+export interface TestResponse {
+  data: {
+    wordbook: Wordbook
+    words: Word[]
+  }
+}

--- a/frontend/src/types/wordbook.ts
+++ b/frontend/src/types/wordbook.ts
@@ -1,0 +1,8 @@
+export interface Wordbook {
+  id: number
+  name: string
+}
+
+export interface WordbookListResponse {
+  data: Wordbook[]
+}


### PR DESCRIPTION
## 概要

- Issue #16 として、テストページ（単語帳選択・出題数指定・テスト実行・結果表示）をReact SPAとして実装

## 主な実装

- **`frontend/src/types/wordbook.ts`**：`Wordbook`型・`WordbookListResponse`型を定義（`types/word.ts`の型定義パターンを踏襲）
- **`frontend/src/types/test.ts`**：`GET /api/test`のレスポンス型`TestResponse`を定義
- **`frontend/src/api/wordbooks.ts`**：`fetchWordbooks()`を追加。`api/words.ts`の`fetch` + `VITE_API_BASE_URL`パターンを再利用
- **`frontend/src/api/test.ts`**：`fetchTest(wordbookId, count)`を追加。クエリパラメータで`wordbook_id`・`count`を送信
- **`frontend/src/components/Test.tsx`**：`'form' | 'quiz' | 'result'`の3フェーズで画面状態を管理。単語帳選択・出題数指定（デフォルト20問）→ 1問ずつ「答えを見る」→「理解した」/「理解していない」で自己採点する既存Blade（`test.blade.php`）と同じフローを実装し、最後に結果を表示。単語帳一覧取得・テスト開始それぞれにローディング・エラー表示、二重送信防止を実装
- **`frontend/src/App.tsx`**：`<Route path="/test" element={<Test />} />` を追加

## Figma / 設計書との差異・補足

- 出題UIの詳細（英単語表示→答え表示ボタン→理解した/理解していない自己採点）はIssue本文に明記がなかったため、既存Blade実装（`resources/views/test.blade.php`）と同じ方式を採用する旨を`/analyze`時点で人間に確認済み
- `/review`で指摘された「単語0件の単語帳を選択した場合に空白画面になる」問題は、テスト開始時のレスポンスが空配列の場合にエラーメッセージを表示するよう修正済み（フォーム画面に留まる）

## 本PR対象外

- 品詞による絞り込み
- テスト履歴の保存
- 共通ナビゲーションヘッダーの実装（#37で実装済みのため本PRでは変更なし）
- バックエンドAPI（`routes/api.php`・`TestController`・`WordbookController`等、#10で実装済みのため変更なし）

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）
- `npx tsc -b --noEmit` を実行し、型エラーがないことを確認済み

### 受け入れ条件

- [ ] 単語帳を選択し、出題数（デフォルト20問）を指定できる
- [ ] 指定した単語帳からランダムにN問出題される
- [ ] テスト結果が表示される
- [ ] 未認証ユーザーがアクセスできる
- [ ] ローディング状態とエラー状態を適切に表示する
- [ ] Tailwind CSSでモダンなデザインが実装されている
- [ ] 共通ナビゲーションヘッダーが表示される

### リグレッション確認

- [ ] 既存機能（単語一覧ページ）への意図しない影響がない

Closes #16
