### PR TITLE
feat: 管理用単語一覧ページを追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { Route, Routes } from 'react-router-dom'
+import AdminWordList from './components/AdminWordList'
 import Header from './components/Header'
 import Test from './components/Test'
 import WordList from './components/WordList'
@@ -11,6 +12,7 @@ function App() {
       <Routes>
         <Route path="/" element={<WordList />} />
         <Route path="/test" element={<Test />} />
+        <Route path="/admin/words" element={<AdminWordList />} />
       </Routes>
     </>
   )

--- a/frontend/src/api/adminWords.ts
+++ b/frontend/src/api/adminWords.ts
@@ -1,0 +1,23 @@
+import type { WordListResponse } from '../types/word'
+
+export async function fetchAdminWords(page: number): Promise<WordListResponse> {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL
+  const res = await fetch(`${baseUrl}/admin/words?page=${page}`)
+
+  if (!res.ok) {
+    throw new Error('単語一覧の取得に失敗しました。')
+  }
+
+  return res.json() as Promise<WordListResponse>
+}
+
+export async function deleteAdminWord(id: number): Promise<void> {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL
+  const res = await fetch(`${baseUrl}/admin/words/${id}`, {
+    method: 'DELETE',
+  })
+
+  if (!res.ok) {
+    throw new Error('単語の削除に失敗しました。')
+  }
+}

--- a/frontend/src/components/AdminWordList.tsx
+++ b/frontend/src/components/AdminWordList.tsx
@@ -55,8 +55,10 @@ function AdminWordList() {
     setDeleteError(null)
 
     deleteAdminWord(id)
-      .then(() => {
-        setWords((prev) => prev.filter((word) => word.id !== id))
+      .then(() => fetchAdminWords(currentPage))
+      .then((response) => {
+        setWords(response.data)
+        setMeta(response.meta)
       })
       .catch(() => {
         setDeleteError('単語の削除に失敗しました。')

--- a/frontend/src/components/AdminWordList.tsx
+++ b/frontend/src/components/AdminWordList.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { deleteAdminWord, fetchAdminWords } from '../api/adminWords'
+import { PART_OF_SPEECH_LABELS, type PartOfSpeech, type PaginationMeta, type Word } from '../types/word'
+
+const PART_OF_SPEECH_BADGE_STYLES: Record<PartOfSpeech, string> = {
+  名詞: 'bg-blue-100 text-blue-700',
+  動詞: 'bg-green-100 text-green-700',
+  形容詞: 'bg-purple-100 text-purple-700',
+  副詞: 'bg-amber-100 text-amber-700',
+  前置詞: 'bg-pink-100 text-pink-700',
+}
+
+function AdminWordList() {
+  const [words, setWords] = useState<Word[]>([])
+  const [meta, setMeta] = useState<PaginationMeta | null>(null)
+  const [currentPage, setCurrentPage] = useState(1)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [deletingId, setDeletingId] = useState<number | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let ignore = false
+
+    setLoading(true)
+    setError(null)
+
+    fetchAdminWords(currentPage)
+      .then((response) => {
+        if (ignore) return
+        setWords(response.data)
+        setMeta(response.meta)
+      })
+      .catch(() => {
+        if (ignore) return
+        setError('単語一覧の取得に失敗しました。')
+      })
+      .finally(() => {
+        if (ignore) return
+        setLoading(false)
+      })
+
+    return () => {
+      ignore = true
+    }
+  }, [currentPage])
+
+  const handleDelete = (id: number) => {
+    if (deletingId !== null) return
+    if (!window.confirm('この単語を削除しますか？')) return
+
+    setDeletingId(id)
+    setDeleteError(null)
+
+    deleteAdminWord(id)
+      .then(() => {
+        setWords((prev) => prev.filter((word) => word.id !== id))
+      })
+      .catch(() => {
+        setDeleteError('単語の削除に失敗しました。')
+      })
+      .finally(() => {
+        setDeletingId(null)
+      })
+  }
+
+  return (
+    <div className="min-h-screen bg-white px-4 py-10">
+      <div className="mx-auto max-w-3xl">
+        <div className="mb-6 flex items-center justify-between border-b-4 border-green-500 pb-2">
+          <h1 className="text-3xl font-bold text-gray-900">管理：単語一覧</h1>
+          <Link
+            to="/admin/words/create-wordbook"
+            className="rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
+          >
+            単語を追加
+          </Link>
+        </div>
+
+        {loading && <p className="text-gray-500">読み込み中...</p>}
+
+        {!loading && error && (
+          <p role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+            {error}
+          </p>
+        )}
+
+        {!loading && !error && (
+          <>
+            {deleteError && (
+              <p role="alert" className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+                {deleteError}
+              </p>
+            )}
+
+            <div className="overflow-hidden rounded-lg border border-gray-200 shadow-sm">
+              <table className="w-full text-left text-sm">
+                <thead className="bg-green-600 text-white">
+                  <tr>
+                    <th className="px-4 py-3 font-semibold">ID</th>
+                    <th className="px-4 py-3 font-semibold">英単語</th>
+                    <th className="px-4 py-3 font-semibold">日本語</th>
+                    <th className="px-4 py-3 font-semibold">品詞</th>
+                    <th className="px-4 py-3 font-semibold">操作</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {words.map((word) => (
+                    <tr key={word.id} className="hover:bg-green-50">
+                      <td className="px-4 py-3 text-gray-500">{word.id}</td>
+                      <td className="px-4 py-3 font-medium text-gray-900">
+                        <Link to={`/admin/words/${word.id}/edit`} className="hover:text-green-600">
+                          {word.english}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-3 text-gray-700">
+                        <Link to={`/admin/words/${word.id}/edit`} className="hover:text-green-600">
+                          {word.japanese}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ${PART_OF_SPEECH_BADGE_STYLES[word.part_of_speech]}`}
+                        >
+                          {PART_OF_SPEECH_LABELS[word.part_of_speech]}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(word.id)}
+                          disabled={deletingId === word.id}
+                          className="rounded-md bg-red-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-600 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
+                        >
+                          {deletingId === word.id ? '削除中...' : '削除'}
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {meta && (
+              <div className="mt-4 flex items-center justify-center gap-4">
+                <button
+                  type="button"
+                  onClick={() => setCurrentPage((page) => page - 1)}
+                  disabled={meta.current_page <= 1}
+                  className="rounded-md bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
+                >
+                  前へ
+                </button>
+                <span className="text-sm text-gray-600">
+                  {meta.current_page} / {meta.last_page}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setCurrentPage((page) => page + 1)}
+                  disabled={meta.current_page >= meta.last_page}
+                  className="rounded-md bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
+                >
+                  次へ
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default AdminWordList


### PR DESCRIPTION
## 概要

- Issue #17 として、管理用の単語一覧ページ（一覧表示・削除・追加/編集ページへの導線）をReact SPAとして実装

## 主な実装

- **`frontend/src/api/adminWords.ts`**：`fetchAdminWords(page)`・`deleteAdminWord(id)`を追加。`api/words.ts`の`fetch` + `VITE_API_BASE_URL`パターンを再利用し、レスポンス型は既存の`WordListResponse`（`types/word.ts`）をそのまま流用
- **`frontend/src/components/AdminWordList.tsx`**：`WordList.tsx`のローディング/エラー/ページネーションパターンを踏襲した管理用一覧ページ。ID・英単語・日本語・品詞バッジ・操作（削除）列を表示し、各行の英単語/日本語には編集ページ（`/admin/words/:id/edit`）へのLink、上部には単語帳選択ページ（`/admin/words/create-wordbook`）への「単語を追加」リンクを設置。削除は`window.confirm`で確認後に実行し、`deletingId`による二重送信防止、成功時は一覧を再取得して`words`・`meta`（ページネーション情報）を最新化
- **`frontend/src/App.tsx`**：`<Route path="/admin/words" element={<AdminWordList />} />` を追加

## Figma / 設計書との差異・補足

- 「単語追加・編集ページへ遷移できる」という受け入れ条件に対し、遷移先ページ（#18単語帳選択・#20単語編集）は本PRの対象外で未実装。既存の`Header.tsx`が`/test`ルート未実装時点で先にLinkを追加していた前例（#37→#16）と同様、本PRでは意図したパスへのLinkのみを実装し、遷移先ページ自体は関連Issueで対応する
- URLパス命名（`/admin/words`・`/admin/words/create-wordbook`・`/admin/words/:id/edit`・`/admin/wordbooks/add`）は`/analyze`時点で人間に確認済み。#18〜#21もこの命名規則に合わせる想定
- 認証連携（#22）が未実装のため、`/api/admin/words`系エンドポイントは現状常に401を返す。Issueの制約により、この状態のまま進めることを人間に確認済み
- `/review`で指摘された「削除後にページネーション情報（`meta`）が更新されない」問題は、削除成功時に一覧を再取得するよう修正済み
- `/review`で指摘された「操作列追加によるモバイル幅での窮屈さ」は、対応を保留（後日確認予定）

## 本PR対象外

- 単語の検索・絞り込み機能
- 単語帳選択ページ（#18）・単語追加ページ（#19）・単語編集ページ（#20）・単語帳追加ページ（#21）自体の実装
- 認証チェック・未認証時のリダイレクト（#22）
- モバイル幅での操作列の表示崩れ確認（保留、別途確認予定）

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）
- `npx tsc -b --noEmit` を実行し、型エラーがないことを確認済み

### 受け入れ条件

- [ ] 管理用の単語一覧がReactで表示される
- [ ] 単語を削除できる
- [ ] 単語追加・編集ページへ遷移できる
- [ ] ローディング状態とエラー状態を適切に表示する
- [ ] Tailwind CSSでモダンなデザインが実装されている
- [ ] 共通ナビゲーションヘッダーが表示される

### リグレッション確認

- [ ] 既存機能（単語一覧ページ・テストページ）への意図しない影響がない

Closes #17
