### PR TITLE
feat: React SPAとSanctumの認証連携

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+FRONTEND_URL=http://localhost:3000
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null

--- a/backend/app/Http/Kernel.php
+++ b/backend/app/Http/Kernel.php
@@ -39,7 +39,7 @@ class Kernel extends HttpKernel
         ],
 
         'api' => [
-            // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             // \Illuminate\Routing\Middleware\ThrottleRequests::class.':api',
             \App\Http\Middleware\ForceJsonResponse::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,

--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -19,7 +19,7 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => ['*'],
+    'allowed_origins' => [env('FRONTEND_URL', 'http://localhost:3000')],
 
     'allowed_origins_patterns' => [],
 
@@ -29,6 +29,6 @@ return [
 
     'max_age' => 0,
 
-    'supports_credentials' => false,
+    'supports_credentials' => true,
 
 ];

--- a/backend/config/fortify.php
+++ b/backend/config/fortify.php
@@ -77,6 +77,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Redirects
+    |--------------------------------------------------------------------------
+    |
+    | Here you may override the redirect path for individual Fortify actions.
+    | Any action not listed here falls back to the "home" path above.
+    |
+    */
+
+    'redirects' => [
+        'login' => env('FRONTEND_URL', 'http://localhost:3000').'/admin/words',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Fortify Routes Prefix / Subdomain
     |--------------------------------------------------------------------------
     |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { Route, Routes } from 'react-router-dom'
+import AdminRoute from './components/AdminRoute'
 import AdminWordList from './components/AdminWordList'
 import Header from './components/Header'
 import Test from './components/Test'
@@ -12,7 +13,9 @@ function App() {
       <Routes>
         <Route path="/" element={<WordList />} />
         <Route path="/test" element={<Test />} />
-        <Route path="/admin/words" element={<AdminWordList />} />
+        <Route path="/admin" element={<AdminRoute />}>
+          <Route path="words" element={<AdminWordList />} />
+        </Route>
       </Routes>
     </>
   )

--- a/frontend/src/api/adminWords.ts
+++ b/frontend/src/api/adminWords.ts
@@ -1,8 +1,9 @@
 import type { WordListResponse } from '../types/word'
+import { adminFetch } from './httpClient'
 
 export async function fetchAdminWords(page: number): Promise<WordListResponse> {
   const baseUrl = import.meta.env.VITE_API_BASE_URL
-  const res = await fetch(`${baseUrl}/admin/words?page=${page}`)
+  const res = await adminFetch(`${baseUrl}/admin/words?page=${page}`)
 
   if (!res.ok) {
     throw new Error('単語一覧の取得に失敗しました。')
@@ -13,7 +14,7 @@ export async function fetchAdminWords(page: number): Promise<WordListResponse> {
 
 export async function deleteAdminWord(id: number): Promise<void> {
   const baseUrl = import.meta.env.VITE_API_BASE_URL
-  const res = await fetch(`${baseUrl}/admin/words/${id}`, {
+  const res = await adminFetch(`${baseUrl}/admin/words/${id}`, {
     method: 'DELETE',
   })
 

--- a/frontend/src/api/httpClient.ts
+++ b/frontend/src/api/httpClient.ts
@@ -1,0 +1,45 @@
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
+
+export function getBackendOrigin(): string {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL
+  return baseUrl.replace(/\/api\/?$/, '')
+}
+
+function readCookie(name: string): string | null {
+  const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`))
+  return match ? decodeURIComponent(match[1]) : null
+}
+
+async function ensureCsrfCookie(): Promise<void> {
+  await fetch(`${getBackendOrigin()}/sanctum/csrf-cookie`, {
+    credentials: 'include',
+  })
+}
+
+export async function adminFetch(url: string, options: RequestInit = {}): Promise<Response> {
+  const method = (options.method ?? 'GET').toUpperCase()
+  const headers = new Headers(options.headers)
+
+  if (MUTATING_METHODS.has(method)) {
+    await ensureCsrfCookie()
+
+    const token = readCookie('XSRF-TOKEN')
+    if (token) {
+      headers.set('X-XSRF-TOKEN', token)
+    }
+  }
+
+  const res = await fetch(url, {
+    ...options,
+    method,
+    credentials: 'include',
+    headers,
+  })
+
+  if (res.status === 401) {
+    window.location.href = `${getBackendOrigin()}/login`
+    throw new Error('認証が必要です。')
+  }
+
+  return res
+}

--- a/frontend/src/components/AdminRoute.tsx
+++ b/frontend/src/components/AdminRoute.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+import { Outlet } from 'react-router-dom'
+import { adminFetch } from '../api/httpClient'
+
+function AdminRoute() {
+  const [checked, setChecked] = useState(false)
+
+  useEffect(() => {
+    let ignore = false
+    const baseUrl = import.meta.env.VITE_API_BASE_URL
+
+    adminFetch(`${baseUrl}/user`)
+      .then(() => {
+        if (ignore) return
+        setChecked(true)
+      })
+      .catch(() => {
+        // 未認証時はadminFetch内でログイン画面へ遷移済み
+      })
+
+    return () => {
+      ignore = true
+    }
+  }, [])
+
+  if (!checked) {
+    return <p className="px-4 py-10 text-center text-gray-500">確認中...</p>
+  }
+
+  return <Outlet />
+}
+
+export default AdminRoute

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -19,6 +19,11 @@ function Header() {
                 単語テスト
               </Link>
             </li>
+            <li>
+              <Link to="/admin/words" className="text-gray-700 hover:text-green-600">
+                管理
+              </Link>
+            </li>
           </ul>
         </nav>
       </div>


### PR DESCRIPTION
## 概要

- Issue #22 として、React SPAとLaravel（Sanctum）のCookieベース認証連携を実装
- 未認証で管理ページへアクセスした場合や管理系APIが401を返した場合に、既存のBladeログイン画面（`/login`）へリダイレクトする

## 主な実装

- **`backend/app/Http/Kernel.php`**：`api`ミドルウェアグループで`EnsureFrontendRequestsAreStateful`を有効化し、Sanctum SPA向けのCookie認証を成立させる
- **`backend/config/cors.php`**：許可オリジンを`FRONTEND_URL`（フロントエンドの実オリジン）に限定し、`supports_credentials`を有効化してCookie送受信を許可する
- **`backend/config/fortify.php`**：ログイン専用の`redirects.login`を追加し、Bladeログイン成功後にReactの`/admin/words`へ遷移させる（`home`は`/list`のまま維持し、登録・パスワードリセット等の他フローには影響しない）
- **`backend/.env` / `backend/.env.example`**：`FRONTEND_URL`環境変数を追加
- **`frontend/src/api/httpClient.ts`（新規）**：管理系API共通のfetchラッパー。Cookie送信、CSRF Cookie取得と`X-XSRF-TOKEN`ヘッダー付与、401時のログイン画面遷移を担う
- **`frontend/src/api/adminWords.ts`**：生の`fetch()`を上記`httpClient`経由に置き換え
- **`frontend/src/components/AdminRoute.tsx`（新規）**：`/admin`配下の認証ガード。マウント時に`GET /api/user`で認証確認し、未認証なら`/login`へリダイレクト
- **`frontend/src/App.tsx`**：`/admin`をネストRouteにし、`AdminRoute`でラップ（将来追加される管理ページも自動的に保護対象になる）
- **`frontend/src/components/Header.tsx`**：ヘッダーに管理ページ（`/admin/words`）への導線を追加し、動作確認の起点を用意

## 本PR対象外

- Auth0・Googleログインの導入
- ログインページのReact化（Bladeを維持）
- 既存Bladeビューの削除
- `#18〜#21`で追加予定の管理画面本体の実装

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] 未認証で管理ページにアクセスすると`/login`にリダイレクトされる
- [ ] Bladeログイン後、管理ページを操作できる
- [ ] 管理系APIから401が返った際に`/login`へリダイレクトされる

### リグレッション確認

- [ ] 既存機能への意図しない影響がない

Closes #22
