### PR TITLE
feat: 単語帳選択ページを追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { Route, Routes } from 'react-router-dom'
 import AdminRoute from './components/AdminRoute'
+import AdminWordbookSelect from './components/AdminWordbookSelect'
 import AdminWordList from './components/AdminWordList'
 import Header from './components/Header'
 import Test from './components/Test'
@@ -15,6 +16,7 @@ function App() {
         <Route path="/test" element={<Test />} />
         <Route path="/admin" element={<AdminRoute />}>
           <Route path="words" element={<AdminWordList />} />
+          <Route path="words/create-wordbook" element={<AdminWordbookSelect />} />
         </Route>
       </Routes>
     </>

--- a/frontend/src/api/adminWordbooks.ts
+++ b/frontend/src/api/adminWordbooks.ts
@@ -1,0 +1,13 @@
+import type { WordbookListResponse } from '../types/wordbook'
+import { adminFetch } from './httpClient'
+
+export async function fetchAdminWordbooks(): Promise<WordbookListResponse> {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL
+  const res = await adminFetch(`${baseUrl}/admin/wordbooks`)
+
+  if (!res.ok) {
+    throw new Error('単語帳一覧の取得に失敗しました。')
+  }
+
+  return res.json() as Promise<WordbookListResponse>
+}

--- a/frontend/src/components/AdminWordbookSelect.tsx
+++ b/frontend/src/components/AdminWordbookSelect.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { fetchAdminWordbooks } from '../api/adminWordbooks'
+import type { Wordbook } from '../types/wordbook'
+
+function AdminWordbookSelect() {
+  const [wordbooks, setWordbooks] = useState<Wordbook[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let ignore = false
+
+    setLoading(true)
+    setError(null)
+
+    fetchAdminWordbooks()
+      .then((response) => {
+        if (ignore) return
+        setWordbooks(response.data)
+      })
+      .catch(() => {
+        if (ignore) return
+        setError('単語帳一覧の取得に失敗しました。')
+      })
+      .finally(() => {
+        if (ignore) return
+        setLoading(false)
+      })
+
+    return () => {
+      ignore = true
+    }
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-white px-4 py-10">
+      <div className="mx-auto max-w-3xl">
+        <div className="mb-6 border-b-4 border-green-500 pb-2">
+          <h1 className="text-3xl font-bold text-gray-900">単語帳を選択</h1>
+        </div>
+
+        {loading && <p className="text-gray-500">読み込み中...</p>}
+
+        {!loading && error && (
+          <p role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+            {error}
+          </p>
+        )}
+
+        {!loading && !error && wordbooks.length === 0 && (
+          <p className="text-gray-700">
+            単語帳がありません。
+            <Link to="/admin/wordbooks/add" className="text-green-600 hover:underline">
+              単語帳を追加する
+            </Link>
+          </p>
+        )}
+
+        {!loading && !error && wordbooks.length > 0 && (
+          <ul className="divide-y divide-gray-100 overflow-hidden rounded-lg border border-gray-200 shadow-sm">
+            {wordbooks.map((wordbook) => (
+              <li key={wordbook.id}>
+                <Link
+                  to={`/admin/words/create-wordbook/${wordbook.id}`}
+                  className="block px-4 py-3 font-medium text-gray-900 hover:bg-green-50 hover:text-green-600"
+                >
+                  {wordbook.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default AdminWordbookSelect


### PR DESCRIPTION
## 概要

- Issue #18 として、単語追加前に登録先の単語帳を選択するReact SPAページを実装

## 主な実装

- **`frontend/src/api/adminWordbooks.ts`**：`GET /admin/wordbooks`を呼び出す`fetchAdminWordbooks()`を追加。`api/adminWords.ts`と同じ`res.ok`チェック＋例外throwパターンで実装し、認証保護された`adminFetch`（Cookie認証・CSRF対応）を利用
- **`frontend/src/components/AdminWordbookSelect.tsx`**：単語帳一覧を表示し、選択すると`/admin/words/create-wordbook/{wordbook.id}`へ遷移するページを追加。`AdminWordList.tsx`と同じloading/error状態管理パターンとTailwindスタイルを踏襲。単語帳0件時は案内メッセージと`/admin/wordbooks/add`へのリンクを表示
- **`frontend/src/App.tsx`**：`/admin/words/create-wordbook`ルートを`AdminRoute`配下に追加

## 本PR対象外

- 単語帳の新規作成・編集・削除機能
- 単語追加ページ本体（#19）・単語編集ページ（#20）・単語帳追加ページ（#21）：本PRでは遷移先へのLinkのみ

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] 単語帳の一覧が表示される
- [ ] 単語帳を選択すると、その単語帳への単語追加ページへ遷移できる
- [ ] Tailwind CSSでモダンなデザインが実装されている
- [ ] 共通ナビゲーションヘッダーが表示される

### リグレッション確認

- [ ] 既存機能（単語一覧・テスト・管理単語一覧ページ）への意図しない影響がない

Closes #18
