### PR TITLE
feat: 管理用単語追加ページを追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { Route, Routes } from 'react-router-dom'
 import AdminRoute from './components/AdminRoute'
 import AdminWordbookSelect from './components/AdminWordbookSelect'
+import AdminWordCreate from './components/AdminWordCreate'
 import AdminWordList from './components/AdminWordList'
 import Header from './components/Header'
 import Test from './components/Test'
@@ -17,6 +18,7 @@ function App() {
         <Route path="/admin" element={<AdminRoute />}>
           <Route path="words" element={<AdminWordList />} />
           <Route path="words/create-wordbook" element={<AdminWordbookSelect />} />
+          <Route path="words/create-wordbook/:wordbookId" element={<AdminWordCreate />} />
         </Route>
       </Routes>
     </>

--- a/frontend/src/api/adminWords.ts
+++ b/frontend/src/api/adminWords.ts
@@ -1,5 +1,13 @@
-import type { WordListResponse } from '../types/word'
+import type { PartOfSpeech, WordListResponse } from '../types/word'
 import { adminFetch } from './httpClient'
+
+export interface CreateAdminWordPayload {
+  english: string
+  japanese: string
+  part_of_speech: PartOfSpeech
+  wordbook_id: number
+  order: number
+}
 
 export async function fetchAdminWords(page: number): Promise<WordListResponse> {
   const baseUrl = import.meta.env.VITE_API_BASE_URL
@@ -10,6 +18,19 @@ export async function fetchAdminWords(page: number): Promise<WordListResponse> {
   }
 
   return res.json() as Promise<WordListResponse>
+}
+
+export async function createAdminWord(payload: CreateAdminWordPayload): Promise<void> {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL
+  const res = await adminFetch(`${baseUrl}/admin/words`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+
+  if (!res.ok) {
+    throw new Error('単語の登録に失敗しました。')
+  }
 }
 
 export async function deleteAdminWord(id: number): Promise<void> {

--- a/frontend/src/components/AdminWordCreate.tsx
+++ b/frontend/src/components/AdminWordCreate.tsx
@@ -1,0 +1,132 @@
+import { useState, type FormEvent } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { createAdminWord } from '../api/adminWords'
+import type { PartOfSpeech } from '../types/word'
+
+const PART_OF_SPEECH_OPTIONS: PartOfSpeech[] = ['名詞', '動詞', '形容詞', '副詞', '前置詞']
+
+function AdminWordCreate() {
+  const { wordbookId } = useParams<{ wordbookId: string }>()
+  const navigate = useNavigate()
+
+  const [english, setEnglish] = useState('')
+  const [japanese, setJapanese] = useState('')
+  const [partOfSpeech, setPartOfSpeech] = useState<PartOfSpeech | ''>('')
+  const [order, setOrder] = useState('')
+
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (submitting || !wordbookId || !partOfSpeech) return
+
+    setSubmitting(true)
+    setSubmitError(null)
+
+    createAdminWord({
+      english,
+      japanese,
+      part_of_speech: partOfSpeech,
+      wordbook_id: Number(wordbookId),
+      order: Number(order),
+    })
+      .then(() => {
+        navigate('/admin/words')
+      })
+      .catch(() => {
+        setSubmitError('単語の登録に失敗しました。')
+      })
+      .finally(() => {
+        setSubmitting(false)
+      })
+  }
+
+  return (
+    <div className="min-h-screen bg-white px-4 py-10">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="mb-6 border-b-4 border-green-500 pb-2 text-3xl font-bold text-gray-900">単語を追加</h1>
+
+        <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-gray-200 p-6 shadow-sm">
+          <div>
+            <label htmlFor="english" className="mb-1 block text-sm font-medium text-gray-700">
+              英単語
+            </label>
+            <input
+              id="english"
+              type="text"
+              required
+              value={english}
+              onChange={(event) => setEnglish(event.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="japanese" className="mb-1 block text-sm font-medium text-gray-700">
+              日本語
+            </label>
+            <input
+              id="japanese"
+              type="text"
+              required
+              value={japanese}
+              onChange={(event) => setJapanese(event.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+            />
+          </div>
+
+          <fieldset>
+            <legend className="mb-1 text-sm font-medium text-gray-700">品詞</legend>
+            <div className="flex flex-wrap gap-4">
+              {PART_OF_SPEECH_OPTIONS.map((option) => (
+                <label key={option} className="flex items-center gap-1.5 text-sm text-gray-700">
+                  <input
+                    type="radio"
+                    name="part_of_speech"
+                    value={option}
+                    required
+                    checked={partOfSpeech === option}
+                    onChange={() => setPartOfSpeech(option)}
+                  />
+                  {option}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <div>
+            <label htmlFor="order" className="mb-1 block text-sm font-medium text-gray-700">
+              No
+            </label>
+            <input
+              id="order"
+              type="number"
+              min={1}
+              required
+              value={order}
+              onChange={(event) => setOrder(event.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+            />
+          </div>
+
+          {submitError && (
+            <p role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+              {submitError}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
+          >
+            {submitting ? '登録中...' : '追加する'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default AdminWordCreate


### PR DESCRIPTION
## 概要

- Issue #19 として、単語帳選択ページ（#18）から遷移する単語追加ページをReact SPAとして実装

## 主な実装

- **`frontend/src/components/AdminWordCreate.tsx`**：単語追加フォーム。URLパラメータ`wordbookId`を`useParams`で取得し、英単語・日本語・品詞（ラジオボタン・必須）・No（order）を入力して登録できる。`Test.tsx`のフォーム状態管理パターン（`submitting`/`submitError`）を再利用し、二重送信防止とエラー表示を行う。送信成功時は`/admin/words`へ遷移する。
- **`frontend/src/api/adminWords.ts`**：`createAdminWord`関数を追加し、`POST /admin/words`へ単語登録を送信する。既存の`fetchAdminWords`・`deleteAdminWord`と同じ`adminFetch`呼び出しパターンを再利用。
- **`frontend/src/App.tsx`**：`AdminRoute`配下に`words/create-wordbook/:wordbookId`ルートを追加し、`AdminWordCreate`を紐づけた。

## Figma / 設計書との差異・補足

- Issue本文には「No（order）を空白のまま登録できる（任意）」とあるが、現在のバックエンド仕様（Issue #27で`order`をNOT NULL・必須へ確定済み）と矛盾していたため、`/analyze`時に確認のうえ「orderは必須」として実装することで承認を得た（Issue #19コメントの承認済み実装方針を参照）。

## 本PR対象外

- バックエンドの`order`任意化（現行のIssue #27の仕様を維持）
- 単語帳追加ページ（未実装、別Issue）

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] 品詞をラジオボタンで選択できる（名詞・動詞・形容詞・副詞・前置詞）
- [ ] 品詞を選択せずに送信するとバリデーションエラーが表示される
- [ ] `order`（No）は必須入力とする（承認済み方針により変更）
- [ ] 送信中の二重送信を防止する
- [ ] ローディング状態とエラー状態を適切に表示する
- [ ] Tailwind CSSでモダンなデザインが実装されている
- [ ] 共通ナビゲーションヘッダーが表示される

### リグレッション確認

- [ ] 単語一覧・単語帳選択・単語削除など既存ページの表示や動作に影響がない

Closes #19
