### PR TITLE
feat: 管理用単語1件取得APIと更新APIの内容のみ更新対応

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/WordController.php
+++ b/backend/app/Http/Controllers/Api/Admin/WordController.php
@@ -8,6 +8,7 @@ use App\Http\Resources\WordResource;
 use App\Models\Word;
 use App\UseCases\Admin\CreateWordUseCase;
 use App\UseCases\Admin\DeleteWordUseCase;
+use App\UseCases\Admin\ShowWordUseCase;
 use App\UseCases\Admin\UpdateWordUseCase;
 use App\UseCases\Api\Word\ListWordsUseCase;
 
@@ -16,6 +17,7 @@ class WordController extends Controller
 	public function __construct(
 		private ListWordsUseCase $listWordsUseCase,
 		private CreateWordUseCase $createWordUseCase,
+		private ShowWordUseCase $showWordUseCase,
 		private UpdateWordUseCase $updateWordUseCase,
 		private DeleteWordUseCase $deleteWordUseCase,
 	) {
@@ -36,6 +38,12 @@ class WordController extends Controller
 		];
 		$this->createWordUseCase->execute($wordData, $request->wordbook_id, $request->order);
 		return response()->noContent(201);
+	}
+
+	public function show(Word $word)
+	{
+		$word = $this->showWordUseCase->execute($word->id);
+		return new WordResource($word);
 	}
 
 	public function update(AdminRequest $request, Word $word)

--- a/backend/app/Http/Requests/AdminRequest.php
+++ b/backend/app/Http/Requests/AdminRequest.php
@@ -21,12 +21,18 @@ class AdminRequest extends FormRequest
 	 */
 	public function rules(): array
 	{
+		$isUpdate = $this->isMethod('put');
+
 		return [
 			'english' => 'required|string|max:255',
 			'japanese' => 'required|string|max:255',
 			'part_of_speech' => 'required|in:名詞,動詞,形容詞,副詞,前置詞',
-			'wordbook_id' => 'required|integer|exists:wordbooks,id',
-			'order' => 'required|integer|min:1',
+			'wordbook_id' => $isUpdate
+				? 'required_with:order|integer|exists:wordbooks,id'
+				: 'required|integer|exists:wordbooks,id',
+			'order' => $isUpdate
+				? 'required_with:wordbook_id|integer|min:1'
+				: 'required|integer|min:1',
 		];
 	}
 
@@ -37,7 +43,9 @@ class AdminRequest extends FormRequest
 			'japanese.required' => '日本語訳は必須です。',
 			'part_of_speech.required' => '品詞の選択は必須です。',
 			'wordbook_id.required' => '単語帳の選択は必須です。',
+			'wordbook_id.required_with' => '順序を指定する場合は単語帳の選択も必須です。',
 			'order.required' => '順序は必須です。',
+			'order.required_with' => '単語帳を指定する場合は順序も必須です。',
 			'order.min' => '順序は1以上である必要があります。',
 		];
 	}

--- a/backend/app/UseCases/Admin/ShowWordUseCase.php
+++ b/backend/app/UseCases/Admin/ShowWordUseCase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\UseCases\Admin;
+
+use App\Interfaces\WordRepositoryInterface;
+use App\Models\Word;
+
+class ShowWordUseCase
+{
+	public function __construct(
+		private WordRepositoryInterface $wordRepository,
+	) {
+	}
+
+	public function execute(int $id): Word
+	{
+		return $this->wordRepository->find($id);
+	}
+}

--- a/backend/app/UseCases/Admin/UpdateWordUseCase.php
+++ b/backend/app/UseCases/Admin/UpdateWordUseCase.php
@@ -11,10 +11,13 @@ class UpdateWordUseCase
 	) {
 	}
 
-	public function execute(int $id, array $wordData, int $wordbookId, int $order): void
+	public function execute(int $id, array $wordData, ?int $wordbookId = null, ?int $order = null): void
 	{
 		$word = $this->wordRepository->find($id);
 		$this->wordRepository->update($word, $wordData);
-		$this->wordRepository->syncWordbookWithoutDetaching($word, $wordbookId, $order);
+
+		if ($wordbookId !== null && $order !== null) {
+			$this->wordRepository->syncWordbookWithoutDetaching($word, $wordbookId, $order);
+		}
 	}
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -30,6 +30,7 @@ Route::get('/test', [TestController::class, 'index'])->name('api.test.index');
 Route::middleware('auth:sanctum')->prefix('admin')->name('api.admin.')->group(function () {
     Route::get('/words', [AdminWordController::class, 'index'])->name('words.index');
     Route::post('/words', [AdminWordController::class, 'store'])->name('words.store');
+    Route::get('/words/{word}', [AdminWordController::class, 'show'])->name('words.show');
     Route::put('/words/{word}', [AdminWordController::class, 'update'])->name('words.update');
     Route::delete('/words/{word}', [AdminWordController::class, 'destroy'])->name('words.destroy');
     Route::get('/wordbooks', [AdminWordbookController::class, 'index'])->name('wordbooks.index');


### PR DESCRIPTION
## 概要

- Issue #45 として、管理用単語1件取得エンドポイント（`GET /api/admin/words/{word}`）を新設し、更新エンドポイント（`PUT /api/admin/words/{word}`）を`wordbook_id`・`order`なしでも呼び出せるよう仕様変更した
- 前提Issue #20（単語編集ページ）が本APIを利用するためのAPI整備であり、`order`は単語帳ごとに異なり一意に決まらないため編集対象から外すという#20コメントでの合意に基づく

## 主な実装

- **`backend/routes/api.php`**：`admin`グループへ`GET /words/{word}`（`show`）ルートを追加
- **`backend/app/UseCases/Admin/ShowWordUseCase.php`**（新規）：`WordRepositoryInterface::find()`を呼ぶだけの薄いUseCase。`UpdateWordUseCase`・`DeleteWordUseCase`と同じ「Controllerで解決済みの`Word`からIDのみ渡し、UseCase内で再取得する」既存パターンを踏襲
- **`backend/app/Http/Controllers/Api/Admin/WordController.php`**：`show(Word $word)`アクションを追加し、`WordResource`で返却
- **`backend/app/Http/Requests/AdminRequest.php`**：`rules()`をHTTPメソッドで分岐。POST（`store`）は`wordbook_id`・`order`とも従来通り必須のまま維持し、PUT（`update`）は`required_with`により「両方省略可・片方だけの送信は422」とした
- **`backend/app/UseCases/Admin/UpdateWordUseCase.php`**：`wordbookId`・`order`をnullable化し、両方揃っている場合のみ`syncWordbookWithoutDetaching`でpivot（order）を更新するよう変更

## Figma / 設計書との差異・補足

- 承認済み実装方針の事前確認事項として、「`wordbook_id`・`order`の片方だけ送信された場合の挙動」を人間へ確認し、422エラーとする案（`required_with`によるバリデーション）で確定した
- レビュー時の指摘で、`AdminRequest::messages()`への`required_with`用日本語メッセージ追加は承認済み方針シートのコード例に明記がなかったが、既存の`messages()`の日本語化方針との整合性を保つための同一ファイル内の付随変更として、人間の承認を得た上でそのまま採用している

## 本PR対象外

- レスポンスへの`order`・`wordbook_id`追加（#20参照）
- 単語作成（`POST`）・削除（`DELETE`）エンドポイントの変更
- 単語帳ごとの`order`編集UI・API

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応、`backend/tests/`のテスト方針は未確定）

### 受け入れ条件

- [ ] `GET /api/admin/words/{word}` にリクエストすると、該当する単語の `id`・`english`・`japanese`・`part_of_speech` がJSONで返る
- [ ] 存在しない単語IDを指定すると404が返る（GET/PUT共通）
- [ ] 未認証でアクセスすると401が返る（GET/PUT共通）
- [ ] `PUT /api/admin/words/{word}` へ `english`・`japanese`・`part_of_speech` のみ送信すると、単語内容が更新され、単語帳への所属（`order`含む）は変更されない
- [ ] `wordbook_id`・`order`を送信した場合は、従来通り該当単語帳のpivot（order）も更新される

### リグレッション確認

- [ ] `POST /api/admin/words`が`wordbook_id`・`order`なしでは従来通り422になる（store側への影響がないこと）

Closes #45
