### PR TITLE
feat: 管理用単語編集ページを追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Route, Routes } from 'react-router-dom'
 import AdminRoute from './components/AdminRoute'
 import AdminWordbookSelect from './components/AdminWordbookSelect'
 import AdminWordCreate from './components/AdminWordCreate'
+import AdminWordEdit from './components/AdminWordEdit'
 import AdminWordList from './components/AdminWordList'
 import Header from './components/Header'
 import Test from './components/Test'
@@ -19,6 +20,7 @@ function App() {
           <Route path="words" element={<AdminWordList />} />
           <Route path="words/create-wordbook" element={<AdminWordbookSelect />} />
           <Route path="words/create-wordbook/:wordbookId" element={<AdminWordCreate />} />
+          <Route path="words/:id/edit" element={<AdminWordEdit />} />
         </Route>
       </Routes>
     </>

--- a/frontend/src/api/adminWords.ts
+++ b/frontend/src/api/adminWords.ts
@@ -1,4 +1,4 @@
-import type { PartOfSpeech, WordListResponse } from '../types/word'
+import type { PartOfSpeech, Word, WordListResponse } from '../types/word'
 import { adminFetch } from './httpClient'
 
 export interface CreateAdminWordPayload {
@@ -7,6 +7,12 @@ export interface CreateAdminWordPayload {
   part_of_speech: PartOfSpeech
   wordbook_id: number
   order: number
+}
+
+export interface UpdateAdminWordPayload {
+  english: string
+  japanese: string
+  part_of_speech: PartOfSpeech
 }
 
 export async function fetchAdminWords(page: number): Promise<WordListResponse> {
@@ -41,5 +47,30 @@ export async function deleteAdminWord(id: number): Promise<void> {
 
   if (!res.ok) {
     throw new Error('単語の削除に失敗しました。')
+  }
+}
+
+export async function fetchAdminWord(id: number): Promise<Word> {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL
+  const res = await adminFetch(`${baseUrl}/admin/words/${id}`)
+
+  if (!res.ok) {
+    throw new Error('単語の取得に失敗しました。')
+  }
+
+  const json = (await res.json()) as { data: Word }
+  return json.data
+}
+
+export async function updateAdminWord(id: number, payload: UpdateAdminWordPayload): Promise<void> {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL
+  const res = await adminFetch(`${baseUrl}/admin/words/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+
+  if (!res.ok) {
+    throw new Error('単語の更新に失敗しました。')
   }
 }

--- a/frontend/src/components/AdminWordEdit.tsx
+++ b/frontend/src/components/AdminWordEdit.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState, type FormEvent } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { fetchAdminWord, updateAdminWord } from '../api/adminWords'
+import type { PartOfSpeech } from '../types/word'
+
+const PART_OF_SPEECH_OPTIONS: PartOfSpeech[] = ['名詞', '動詞', '形容詞', '副詞', '前置詞']
+
+function AdminWordEdit() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+
+  const [english, setEnglish] = useState('')
+  const [japanese, setJapanese] = useState('')
+  const [partOfSpeech, setPartOfSpeech] = useState<PartOfSpeech | ''>('')
+
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+
+    let ignore = false
+
+    setLoading(true)
+    setError(null)
+
+    fetchAdminWord(Number(id))
+      .then((word) => {
+        if (ignore) return
+        setEnglish(word.english)
+        setJapanese(word.japanese)
+        setPartOfSpeech(word.part_of_speech)
+      })
+      .catch(() => {
+        if (ignore) return
+        setError('単語の取得に失敗しました。')
+      })
+      .finally(() => {
+        if (ignore) return
+        setLoading(false)
+      })
+
+    return () => {
+      ignore = true
+    }
+  }, [id])
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (submitting || !id || !partOfSpeech) return
+
+    setSubmitting(true)
+    setSubmitError(null)
+
+    updateAdminWord(Number(id), {
+      english,
+      japanese,
+      part_of_speech: partOfSpeech,
+    })
+      .then(() => {
+        navigate('/admin/words')
+      })
+      .catch(() => {
+        setSubmitError('単語の更新に失敗しました。')
+      })
+      .finally(() => {
+        setSubmitting(false)
+      })
+  }
+
+  return (
+    <div className="min-h-screen bg-white px-4 py-10">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="mb-6 border-b-4 border-green-500 pb-2 text-3xl font-bold text-gray-900">単語を編集</h1>
+
+        {loading && <p className="text-gray-500">読み込み中...</p>}
+
+        {!loading && error && (
+          <p role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+            {error}
+          </p>
+        )}
+
+        {!loading && !error && (
+          <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-gray-200 p-6 shadow-sm">
+            <div>
+              <label htmlFor="english" className="mb-1 block text-sm font-medium text-gray-700">
+                英単語
+              </label>
+              <input
+                id="english"
+                type="text"
+                required
+                value={english}
+                onChange={(event) => setEnglish(event.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="japanese" className="mb-1 block text-sm font-medium text-gray-700">
+                日本語
+              </label>
+              <input
+                id="japanese"
+                type="text"
+                required
+                value={japanese}
+                onChange={(event) => setJapanese(event.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+              />
+            </div>
+
+            <fieldset>
+              <legend className="mb-1 text-sm font-medium text-gray-700">品詞</legend>
+              <div className="flex flex-wrap gap-4">
+                {PART_OF_SPEECH_OPTIONS.map((option) => (
+                  <label key={option} className="flex items-center gap-1.5 text-sm text-gray-700">
+                    <input
+                      type="radio"
+                      name="part_of_speech"
+                      value={option}
+                      required
+                      checked={partOfSpeech === option}
+                      onChange={() => setPartOfSpeech(option)}
+                    />
+                    {option}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+
+            <p className="text-sm text-gray-500">Noを変更したい場合は、単語を削除してから登録し直してください。</p>
+
+            {submitError && (
+              <p role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+                {submitError}
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
+            >
+              {submitting ? '更新中...' : '更新する'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default AdminWordEdit


### PR DESCRIPTION
## 概要

- Issue #20 として、管理用単語編集ページをReact SPAとして実装
- 承認済み実装方針により、`order`（No）は単語帳ごとに異なり単語編集ページ単体では一意に決まらないため、編集対象から除外。編集対象は英語・日本語・品詞の3項目のみ

## 主な実装

- **`frontend/src/api/adminWords.ts`**：単語1件取得用の`fetchAdminWord`、内容更新用の`updateAdminWord`（`english`・`japanese`・`part_of_speech`のみ送信）を追加。既存の`fetchAdminWords`・`createAdminWord`と同じ`adminFetch`呼び出しパターンを再利用
- **`frontend/src/components/AdminWordEdit.tsx`**：単語編集フォームを新規作成。マウント時に既存データを取得してフォームへ表示し、品詞はラジオボタンで変更可能。`submitting`・`submitError`による二重送信防止とエラー表示、取得中・取得失敗時のローディング／エラー表示を実装。`AdminWordCreate.tsx`のフォーム状態管理パターン、`AdminWordList.tsx`のローディング／エラー表示パターンを再利用
- **`frontend/src/App.tsx`**：`AdminRoute`配下に`words/:id/edit`ルートを追加（`AdminWordList.tsx`に実装済みの編集リンクの遷移先を有効化）

## Figma / 設計書との差異・補足

- Issue本文の受け入れ条件「`order`（No）を空白にして保存できる」は、承認済み実装方針コメントにより対象外へ変更されている。単語は複数単語帳に所属し得るため、`order`は単語帳ごとに異なり単語編集ページ単体では一意に決まらないことが理由
- `order`を変更したい場合の代替手段として、フォーム下部に「Noを変更したい場合は、単語を削除してから登録し直してください。」という注記を表示

## 本PR対象外

- `order`・`wordbook_id`の編集UI・API（単語帳ごとの`order`編集は別途検討）
- テストコードの追加（テスト方針は未確定）

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）
- `tsc --noEmit`・`npm run lint`（oxlint）は実行しエラーなしを確認済み

### 受け入れ条件

- [x] 既存の単語データがフォームに表示される
- [x] 品詞をラジオボタンで変更できる
- [ ] `order`（No）を空白にして保存できる（承認済み方針により対象外）
- [x] 送信中の二重送信を防止する
- [x] ローディング状態とエラー状態を適切に表示する
- [x] Tailwind CSSでモダンなデザインが実装されている
- [x] 共通ナビゲーションヘッダーが表示される

### リグレッション確認

- [ ] 既存機能への意図しない影響がない（単語一覧・単語追加・単語削除）

Closes #20
