### PR TITLE
feat: 管理 単語帳追加ページを追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { Route, Routes } from 'react-router-dom'
 import AdminRoute from './components/AdminRoute'
+import AdminWordbookCreate from './components/AdminWordbookCreate'
 import AdminWordbookSelect from './components/AdminWordbookSelect'
 import AdminWordCreate from './components/AdminWordCreate'
 import AdminWordEdit from './components/AdminWordEdit'
@@ -18,6 +19,7 @@ function App() {
         <Route path="/test" element={<Test />} />
         <Route path="/admin" element={<AdminRoute />}>
           <Route path="words" element={<AdminWordList />} />
+          <Route path="wordbooks/add" element={<AdminWordbookCreate />} />
           <Route path="words/create-wordbook" element={<AdminWordbookSelect />} />
           <Route path="words/create-wordbook/:wordbookId" element={<AdminWordCreate />} />
           <Route path="words/:id/edit" element={<AdminWordEdit />} />

--- a/frontend/src/api/adminWordbooks.ts
+++ b/frontend/src/api/adminWordbooks.ts
@@ -1,4 +1,4 @@
-import type { WordbookListResponse } from '../types/wordbook'
+import type { CreateWordbookPayload, WordbookListResponse } from '../types/wordbook'
 import { adminFetch } from './httpClient'
 
 export async function fetchAdminWordbooks(): Promise<WordbookListResponse> {
@@ -10,4 +10,17 @@ export async function fetchAdminWordbooks(): Promise<WordbookListResponse> {
   }
 
   return res.json() as Promise<WordbookListResponse>
+}
+
+export async function createAdminWordbook(payload: CreateWordbookPayload): Promise<void> {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL
+  const res = await adminFetch(`${baseUrl}/admin/wordbooks`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+
+  if (!res.ok) {
+    throw new Error('単語帳の登録に失敗しました。')
+  }
 }

--- a/frontend/src/components/AdminWordbookCreate.tsx
+++ b/frontend/src/components/AdminWordbookCreate.tsx
@@ -1,0 +1,71 @@
+import { useState, type FormEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { createAdminWordbook } from '../api/adminWordbooks'
+
+function AdminWordbookCreate() {
+  const navigate = useNavigate()
+
+  const [name, setName] = useState('')
+
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (submitting) return
+
+    setSubmitting(true)
+    setSubmitError(null)
+
+    createAdminWordbook({ name })
+      .then(() => {
+        navigate('/admin/words')
+      })
+      .catch(() => {
+        setSubmitError('単語帳の登録に失敗しました。')
+      })
+      .finally(() => {
+        setSubmitting(false)
+      })
+  }
+
+  return (
+    <div className="min-h-screen bg-white px-4 py-10">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="mb-6 border-b-4 border-green-500 pb-2 text-3xl font-bold text-gray-900">単語帳を追加</h1>
+
+        <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-gray-200 p-6 shadow-sm">
+          <div>
+            <label htmlFor="name" className="mb-1 block text-sm font-medium text-gray-700">
+              単語帳名
+            </label>
+            <input
+              id="name"
+              type="text"
+              required
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+            />
+          </div>
+
+          {submitError && (
+            <p role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+              {submitError}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
+          >
+            {submitting ? '登録中...' : '追加する'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default AdminWordbookCreate

--- a/frontend/src/types/wordbook.ts
+++ b/frontend/src/types/wordbook.ts
@@ -6,3 +6,7 @@ export interface Wordbook {
 export interface WordbookListResponse {
   data: Wordbook[]
 }
+
+export interface CreateWordbookPayload {
+  name: string
+}


### PR DESCRIPTION
## 概要

- Issue #21 として、単語帳追加ページをReact SPAとして実装

## 主な実装

- **`frontend/src/types/wordbook.ts`**：POST `/api/admin/wordbooks`のリクエストボディ型として`CreateWordbookPayload { name: string }`を追加
- **`frontend/src/api/adminWordbooks.ts`**：単語帳作成用のAPIクライアント関数`createAdminWordbook`を追加（`adminWords.ts`の`createAdminWord`と同一のPOSTパターンを再利用）
- **`frontend/src/components/AdminWordbookCreate.tsx`**（新規）：単語帳名のみを入力するフォームページ。`AdminWordCreate.tsx`のsubmitting/submitError管理・二重送信防止・Tailwindクラスをそのまま踏襲し、送信成功後は`/admin/words`（管理 単語一覧ページ）へ遷移する
- **`frontend/src/App.tsx`**：`/admin`（`AdminRoute`）配下に`wordbooks/add`のRouteを追加。`AdminWordbookSelect.tsx`に既存する「単語帳を追加する」リンク（`/admin/wordbooks/add`）の遷移先として機能する

## Figma / 設計書との差異・補足

- 承認済み実装方針との相違はなし

## 本PR対象外

- 単語帳の編集・削除（Issue本文で対象外と明記）
- バックエンドAPI（`WordbookController`・`WordbookRequest`・`CreateWordbookUseCase`）はIssue #11で実装済みのため変更なし

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] 単語帳名を入力して作成できる
- [ ] 送信中の二重送信を防止する
- [ ] ローディング状態とエラー状態を適切に表示する
- [ ] Tailwind CSSでモダンなデザインが実装されている
- [ ] 共通ナビゲーションヘッダーが表示される

### リグレッション確認

- [ ] 既存機能への意図しない影響がない

Closes #21
