### PR TITLE
style: 単語追加ページのデザイン改善（品詞バッジ配色・戻る導線）

### DIFF
--- a/frontend/src/components/AdminWordCreate.tsx
+++ b/frontend/src/components/AdminWordCreate.tsx
@@ -52,9 +52,9 @@ function AdminWordCreate() {
           <h1 className="mt-2 text-3xl font-bold text-gray-900">単語を追加</h1>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-gray-200 p-6 shadow-sm">
-          <div>
-            <label htmlFor="english" className="mb-1 block text-sm font-medium text-gray-700">
+        <form onSubmit={handleSubmit} className="space-y-6 rounded-lg border border-gray-200 p-6 shadow-sm">
+          <div className="flex items-center gap-3">
+            <label htmlFor="english" className="w-20 shrink-0 text-sm font-medium text-gray-700">
               英単語
             </label>
             <input
@@ -63,12 +63,12 @@ function AdminWordCreate() {
               required
               value={english}
               onChange={(event) => setEnglish(event.target.value)}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+              className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
             />
           </div>
 
-          <div>
-            <label htmlFor="japanese" className="mb-1 block text-sm font-medium text-gray-700">
+          <div className="flex items-center gap-3">
+            <label htmlFor="japanese" className="w-20 shrink-0 text-sm font-medium text-gray-700">
               日本語
             </label>
             <input
@@ -77,13 +77,18 @@ function AdminWordCreate() {
               required
               value={japanese}
               onChange={(event) => setJapanese(event.target.value)}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+              className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
             />
           </div>
 
-          <fieldset>
-            <legend className="mb-1 text-sm font-medium text-gray-700">品詞</legend>
-            <div className="flex flex-wrap gap-2">
+          <div className="flex items-start gap-3">
+            <span id="part-of-speech-label" className="w-20 shrink-0 pt-1 text-sm font-medium text-gray-700">
+              品詞
+            </span>
+            <fieldset
+              aria-labelledby="part-of-speech-label"
+              className="m-0 min-w-0 flex flex-1 flex-wrap gap-2 border-0 p-0"
+            >
               {PART_OF_SPEECH_OPTIONS.map((option) => (
                 <label
                   key={option}
@@ -103,11 +108,11 @@ function AdminWordCreate() {
                   {option}
                 </label>
               ))}
-            </div>
-          </fieldset>
+            </fieldset>
+          </div>
 
-          <div>
-            <label htmlFor="order" className="mb-1 block text-sm font-medium text-gray-700">
+          <div className="flex items-center gap-3">
+            <label htmlFor="order" className="w-20 shrink-0 text-sm font-medium text-gray-700">
               No
             </label>
             <input
@@ -117,7 +122,7 @@ function AdminWordCreate() {
               required
               value={order}
               onChange={(event) => setOrder(event.target.value)}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+              className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
             />
           </div>
 

--- a/frontend/src/components/AdminWordCreate.tsx
+++ b/frontend/src/components/AdminWordCreate.tsx
@@ -1,7 +1,7 @@
 import { useState, type FormEvent } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { createAdminWord } from '../api/adminWords'
-import type { PartOfSpeech } from '../types/word'
+import { PART_OF_SPEECH_BADGE_STYLES, type PartOfSpeech } from '../types/word'
 
 const PART_OF_SPEECH_OPTIONS: PartOfSpeech[] = ['名詞', '動詞', '形容詞', '副詞', '前置詞']
 
@@ -45,7 +45,12 @@ function AdminWordCreate() {
   return (
     <div className="min-h-screen bg-white px-4 py-10">
       <div className="mx-auto max-w-3xl">
-        <h1 className="mb-6 border-b-4 border-green-500 pb-2 text-3xl font-bold text-gray-900">単語を追加</h1>
+        <div className="mb-6 border-b-4 border-green-500 pb-2">
+          <Link to="/admin/words" className="text-sm text-green-600 hover:underline">
+            ← 単語一覧へ戻る
+          </Link>
+          <h1 className="mt-2 text-3xl font-bold text-gray-900">単語を追加</h1>
+        </div>
 
         <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-gray-200 p-6 shadow-sm">
           <div>
@@ -78,9 +83,14 @@ function AdminWordCreate() {
 
           <fieldset>
             <legend className="mb-1 text-sm font-medium text-gray-700">品詞</legend>
-            <div className="flex flex-wrap gap-4">
+            <div className="flex flex-wrap gap-2">
               {PART_OF_SPEECH_OPTIONS.map((option) => (
-                <label key={option} className="flex items-center gap-1.5 text-sm text-gray-700">
+                <label
+                  key={option}
+                  className={`cursor-pointer rounded-full px-3 py-1 text-sm font-semibold has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-green-500 has-[:focus-visible]:ring-offset-1 ${
+                    partOfSpeech === option ? PART_OF_SPEECH_BADGE_STYLES[option] : 'bg-gray-100 text-gray-500'
+                  }`}
+                >
                   <input
                     type="radio"
                     name="part_of_speech"
@@ -88,6 +98,7 @@ function AdminWordCreate() {
                     required
                     checked={partOfSpeech === option}
                     onChange={() => setPartOfSpeech(option)}
+                    className="sr-only"
                   />
                   {option}
                 </label>

--- a/frontend/src/components/AdminWordList.tsx
+++ b/frontend/src/components/AdminWordList.tsx
@@ -1,15 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { deleteAdminWord, fetchAdminWords } from '../api/adminWords'
-import { PART_OF_SPEECH_LABELS, type PartOfSpeech, type PaginationMeta, type Word } from '../types/word'
-
-const PART_OF_SPEECH_BADGE_STYLES: Record<PartOfSpeech, string> = {
-  名詞: 'bg-blue-100 text-blue-700',
-  動詞: 'bg-green-100 text-green-700',
-  形容詞: 'bg-purple-100 text-purple-700',
-  副詞: 'bg-amber-100 text-amber-700',
-  前置詞: 'bg-pink-100 text-pink-700',
-}
+import { PART_OF_SPEECH_BADGE_STYLES, PART_OF_SPEECH_LABELS, type PaginationMeta, type Word } from '../types/word'
 
 function AdminWordList() {
   const [words, setWords] = useState<Word[]>([])

--- a/frontend/src/components/WordList.tsx
+++ b/frontend/src/components/WordList.tsx
@@ -1,14 +1,6 @@
 import { useEffect, useState } from 'react'
 import { fetchWords } from '../api/words'
-import { PART_OF_SPEECH_LABELS, type PartOfSpeech, type PaginationMeta, type Word } from '../types/word'
-
-const PART_OF_SPEECH_BADGE_STYLES: Record<PartOfSpeech, string> = {
-  名詞: 'bg-blue-100 text-blue-700',
-  動詞: 'bg-green-100 text-green-700',
-  形容詞: 'bg-purple-100 text-purple-700',
-  副詞: 'bg-amber-100 text-amber-700',
-  前置詞: 'bg-pink-100 text-pink-700',
-}
+import { PART_OF_SPEECH_BADGE_STYLES, PART_OF_SPEECH_LABELS, type PaginationMeta, type Word } from '../types/word'
 
 function WordList() {
   const [words, setWords] = useState<Word[]>([])

--- a/frontend/src/types/word.ts
+++ b/frontend/src/types/word.ts
@@ -15,6 +15,14 @@ export const PART_OF_SPEECH_LABELS: Record<PartOfSpeech, string> = {
   前置詞: '前',
 }
 
+export const PART_OF_SPEECH_BADGE_STYLES: Record<PartOfSpeech, string> = {
+  名詞: 'bg-blue-100 text-blue-700',
+  動詞: 'bg-green-100 text-green-700',
+  形容詞: 'bg-purple-100 text-purple-700',
+  副詞: 'bg-amber-100 text-amber-700',
+  前置詞: 'bg-pink-100 text-pink-700',
+}
+
 export interface PaginationLinks {
   first: string | null
   last: string | null


### PR DESCRIPTION
## 概要

- Issue #49 として、単語追加ページ（AdminWordCreate.tsx）の品詞選択UIを単語一覧ページの品詞バッジ配色に統一し、単語一覧ページへ戻る導線を追加

## 主な実装

- **`frontend/src/types/word.ts`**：`WordList.tsx`・`AdminWordList.tsx`に重複定義されていた品詞バッジ配色マップ（`PART_OF_SPEECH_BADGE_STYLES`）を共通exportとして集約
- **`frontend/src/components/WordList.tsx`**・**`frontend/src/components/AdminWordList.tsx`**：ローカル定義を削除し、共通定義をimportするよう変更
- **`frontend/src/components/AdminWordCreate.tsx`**：品詞選択の各ラジオボタンを、選択時に一覧ページと同じバッジ配色（名詞:blue/動詞:green/形容詞:purple/副詞:amber/前置詞:pink）で表示するUIに変更。ネイティブの`<input type="radio">`は`sr-only`で維持し、フォーカス表示は`has-[:focus-visible]`で確保。加えて`/admin/words`へ戻る`Link`を見出し付近に追加

## 本PR対象外

- `AdminWordEdit.tsx`（別Issue対応）
- 入力項目（英単語・日本語・品詞・No）の追加・削除
- バリデーションロジックの変更

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] 品詞選択のUIが、一覧ページの品詞バッジ配色（名詞:blue、動詞:green、形容詞:purple、副詞:amber、前置詞:pink）に対応した見た目で選択できる
- [ ] フォーム上に単語一覧ページ（/admin/words）へ戻るリンクが表示され、クリックすると遷移する

### リグレッション確認

- [ ] `WordList.tsx`・`AdminWordList.tsx`の品詞バッジ表示が、共通化後も従来と同じ配色で表示される

Closes #49
