### PR TITLE
style: 単語編集ページの品詞選択UI・戻る導線・ラベル横並びレイアウトを改善

### DIFF
--- a/frontend/src/components/AdminWordEdit.tsx
+++ b/frontend/src/components/AdminWordEdit.tsx
@@ -90,9 +90,9 @@ function AdminWordEdit() {
         )}
 
         {!loading && !error && (
-          <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-gray-200 p-6 shadow-sm">
-            <div>
-              <label htmlFor="english" className="mb-1 block text-sm font-medium text-gray-700">
+          <form onSubmit={handleSubmit} className="space-y-6 rounded-lg border border-gray-200 p-6 shadow-sm">
+            <div className="flex items-center gap-3">
+              <label htmlFor="english" className="w-20 shrink-0 text-sm font-medium text-gray-700">
                 英単語
               </label>
               <input
@@ -101,12 +101,12 @@ function AdminWordEdit() {
                 required
                 value={english}
                 onChange={(event) => setEnglish(event.target.value)}
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+                className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
               />
             </div>
 
-            <div>
-              <label htmlFor="japanese" className="mb-1 block text-sm font-medium text-gray-700">
+            <div className="flex items-center gap-3">
+              <label htmlFor="japanese" className="w-20 shrink-0 text-sm font-medium text-gray-700">
                 日本語
               </label>
               <input
@@ -115,13 +115,18 @@ function AdminWordEdit() {
                 required
                 value={japanese}
                 onChange={(event) => setJapanese(event.target.value)}
-                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+                className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
               />
             </div>
 
-            <fieldset>
-              <legend className="mb-1 text-sm font-medium text-gray-700">品詞</legend>
-              <div className="flex flex-wrap gap-2">
+            <div className="flex items-start gap-3">
+              <span id="part-of-speech-label" className="w-20 shrink-0 pt-1 text-sm font-medium text-gray-700">
+                品詞
+              </span>
+              <fieldset
+                aria-labelledby="part-of-speech-label"
+                className="m-0 min-w-0 flex flex-1 flex-wrap gap-2 border-0 p-0"
+              >
                 {PART_OF_SPEECH_OPTIONS.map((option) => (
                   <label
                     key={option}
@@ -141,8 +146,8 @@ function AdminWordEdit() {
                     {option}
                   </label>
                 ))}
-              </div>
-            </fieldset>
+              </fieldset>
+            </div>
 
             <p className="text-sm text-gray-500">Noを変更したい場合は、単語を削除してから登録し直してください。</p>
 

--- a/frontend/src/components/AdminWordEdit.tsx
+++ b/frontend/src/components/AdminWordEdit.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type FormEvent } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { Link, useNavigate, useParams } from 'react-router-dom'
 import { fetchAdminWord, updateAdminWord } from '../api/adminWords'
-import type { PartOfSpeech } from '../types/word'
+import { PART_OF_SPEECH_BADGE_STYLES, type PartOfSpeech } from '../types/word'
 
 const PART_OF_SPEECH_OPTIONS: PartOfSpeech[] = ['名詞', '動詞', '形容詞', '副詞', '前置詞']
 
@@ -74,7 +74,12 @@ function AdminWordEdit() {
   return (
     <div className="min-h-screen bg-white px-4 py-10">
       <div className="mx-auto max-w-3xl">
-        <h1 className="mb-6 border-b-4 border-green-500 pb-2 text-3xl font-bold text-gray-900">単語を編集</h1>
+        <div className="mb-6 border-b-4 border-green-500 pb-2">
+          <Link to="/admin/words" className="text-sm text-green-600 hover:underline">
+            ← 単語一覧へ戻る
+          </Link>
+          <h1 className="mt-2 text-3xl font-bold text-gray-900">単語を編集</h1>
+        </div>
 
         {loading && <p className="text-gray-500">読み込み中...</p>}
 
@@ -116,9 +121,14 @@ function AdminWordEdit() {
 
             <fieldset>
               <legend className="mb-1 text-sm font-medium text-gray-700">品詞</legend>
-              <div className="flex flex-wrap gap-4">
+              <div className="flex flex-wrap gap-2">
                 {PART_OF_SPEECH_OPTIONS.map((option) => (
-                  <label key={option} className="flex items-center gap-1.5 text-sm text-gray-700">
+                  <label
+                    key={option}
+                    className={`cursor-pointer rounded-full px-3 py-1 text-sm font-semibold has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-green-500 has-[:focus-visible]:ring-offset-1 ${
+                      partOfSpeech === option ? PART_OF_SPEECH_BADGE_STYLES[option] : 'bg-gray-100 text-gray-500'
+                    }`}
+                  >
                     <input
                       type="radio"
                       name="part_of_speech"
@@ -126,6 +136,7 @@ function AdminWordEdit() {
                       required
                       checked={partOfSpeech === option}
                       onChange={() => setPartOfSpeech(option)}
+                      className="sr-only"
                     />
                     {option}
                   </label>


### PR DESCRIPTION
## 概要

- Issue #50 として、単語編集ページ（`AdminWordEdit.tsx`）のデザインを単語一覧ページ・単語追加ページと統一

## 主な実装

- **`frontend/src/components/AdminWordEdit.tsx`**：品詞選択の各ラベルを、一覧ページと共通の`PART_OF_SPEECH_BADGE_STYLES`（名詞:blue、動詞:green、形容詞:purple、副詞:amber、前置詞:pink）を使ったバッジ配色に変更
- **`frontend/src/components/AdminWordEdit.tsx`**：見出し部分に単語一覧ページ（`/admin/words`）へ戻る`Link`を追加
- **`frontend/src/components/AdminWordEdit.tsx`**：英単語・日本語・品詞欄のラベルと入力欄を、単語追加ページ（`AdminWordCreate.tsx`）と同じ横並びレイアウトに変更。品詞欄は`<fieldset><legend>`から`<span id="part-of-speech-label">`＋`<fieldset aria-labelledby>`の構造に変更

## Figma / 設計書との差異・補足

- ラベル横並びレイアウトへの変更は、承認済み実装方針の当初案には含まれていなかったが、実装過程で人間からの追加指示を受けて対応し、Issue #50の実装方針コメントを実装内容に合わせて更新済み

## 本PR対象外

- 入力項目自体の追加・削除（英単語・日本語・品詞の項目構成）
- バリデーションロジックの変更
- 「Noを変更できない仕様」の案内文の変更
- 単語追加ページ（`AdminWordCreate.tsx`）自体の変更（Issue #49で対応済み）

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] 品詞選択のUIが、一覧ページの品詞バッジ配色（名詞:blue、動詞:green、形容詞:purple、副詞:amber、前置詞:pink）に対応した見た目で選択できる
- [ ] フォーム上に単語一覧ページ（/admin/words）へ戻るリンクが表示され、クリックすると遷移する

### リグレッション確認

- [ ] 既存の更新処理（英単語・日本語・品詞の更新、エラー表示、「Noを変更したい場合は〜」案内文）が変更前と同じ挙動を維持している

Closes #50
