### PR TITLE
style: 単語帳選択ページに単語帳追加への導線を常時表示

### DIFF
--- a/frontend/src/components/AdminWordbookCreate.tsx
+++ b/frontend/src/components/AdminWordbookCreate.tsx
@@ -35,8 +35,8 @@ function AdminWordbookCreate() {
         <h1 className="mb-6 border-b-4 border-green-500 pb-2 text-3xl font-bold text-gray-900">単語帳を追加</h1>
 
         <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-gray-200 p-6 shadow-sm">
-          <div>
-            <label htmlFor="name" className="mb-1 block text-sm font-medium text-gray-700">
+          <div className="flex items-center gap-3">
+            <label htmlFor="name" className="w-20 shrink-0 text-sm font-medium text-gray-700">
               単語帳名
             </label>
             <input
@@ -45,7 +45,7 @@ function AdminWordbookCreate() {
               required
               value={name}
               onChange={(event) => setName(event.target.value)}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+              className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
             />
           </div>
 

--- a/frontend/src/components/AdminWordbookSelect.tsx
+++ b/frontend/src/components/AdminWordbookSelect.tsx
@@ -36,8 +36,14 @@ function AdminWordbookSelect() {
   return (
     <div className="min-h-screen bg-white px-4 py-10">
       <div className="mx-auto max-w-3xl">
-        <div className="mb-6 border-b-4 border-green-500 pb-2">
+        <div className="mb-6 flex items-center justify-between border-b-4 border-green-500 pb-2">
           <h1 className="text-3xl font-bold text-gray-900">単語帳を選択</h1>
+          <Link
+            to="/admin/wordbooks/add"
+            className="rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700"
+          >
+            単語帳を追加する
+          </Link>
         </div>
 
         {loading && <p className="text-gray-500">読み込み中...</p>}
@@ -48,14 +54,7 @@ function AdminWordbookSelect() {
           </p>
         )}
 
-        {!loading && !error && wordbooks.length === 0 && (
-          <p className="text-gray-700">
-            単語帳がありません。
-            <Link to="/admin/wordbooks/add" className="text-green-600 hover:underline">
-              単語帳を追加する
-            </Link>
-          </p>
-        )}
+        {!loading && !error && wordbooks.length === 0 && <p className="text-gray-700">単語帳がありません。</p>}
 
         {!loading && !error && wordbooks.length > 0 && (
           <ul className="divide-y divide-gray-100 overflow-hidden rounded-lg border border-gray-200 shadow-sm">


### PR DESCRIPTION
## 概要

- Issue #51 として、単語帳選択ページ（AdminWordbookSelect.tsx）に単語帳追加ページへの導線を常時表示する変更を実装

## 主な実装

- **`AdminWordbookSelect.tsx`**：ヘッダーを`flex items-center justify-between`に変更し、`AdminWordList.tsx`のヘッダー構成パターンを踏襲したボタン型`Link`（`/admin/wordbooks/add`）を単語帳の有無に関わらず常時表示。0件時に重複していた文中の「単語帳を追加する」リンクは削除し、メッセージを「単語帳がありません。」のみに整理。
- **`AdminWordbookCreate.tsx`**：単語帳名入力欄を、単語追加・単語編集ページと同様のラベル横並びレイアウト（`w-20 shrink-0`ラベル＋`flex-1`入力欄）に変更。

## Figma / 設計書との差異・補足

- `AdminWordbookCreate.tsx`の変更は、承認済み実装方針では「変更なし（スコープ外）」とされていた範囲。実装後に人間から明示的な指示（追加Issueを起票せず本ブランチで対応する）があり、Issue #51へその経緯をコメントとして記録した上で追加実施している。

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] 単語帳が0件・1件以上のいずれの場合も、単語帳選択ページに「単語帳を追加する」への導線（リンクまたはボタン）が表示される
- [ ] 導線をクリックすると /admin/wordbooks/add に遷移し、単語帳追加ページが表示される

### リグレッション確認

- [ ] 単語帳一覧の表示・クリック時の遷移（`/admin/words/create-wordbook/:id`）に既存の挙動から変化がないこと
- [ ] レイアウト崩れがないこと（モバイル幅含む）

Closes #51
