### PR TITLE
feat: 単語帳の編集・削除機能を追加

### DIFF
--- a/backend/app/Http/Controllers/Api/Admin/WordbookController.php
+++ b/backend/app/Http/Controllers/Api/Admin/WordbookController.php
@@ -5,7 +5,10 @@ namespace App\Http\Controllers\Api\Admin;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\WordbookRequest;
 use App\Http\Resources\WordbookResource;
+use App\Models\Wordbook;
 use App\UseCases\Admin\CreateWordbookUseCase;
+use App\UseCases\Admin\DeleteWordbookUseCase;
+use App\UseCases\Admin\UpdateWordbookUseCase;
 use App\UseCases\Api\Wordbook\ListWordbooksUseCase;
 
 class WordbookController extends Controller
@@ -13,6 +16,8 @@ class WordbookController extends Controller
 	public function __construct(
 		private ListWordbooksUseCase $listWordbooksUseCase,
 		private CreateWordbookUseCase $createWordbookUseCase,
+		private UpdateWordbookUseCase $updateWordbookUseCase,
+		private DeleteWordbookUseCase $deleteWordbookUseCase,
 	) {
 	}
 
@@ -26,5 +31,17 @@ class WordbookController extends Controller
 	{
 		$this->createWordbookUseCase->execute($request->all());
 		return response()->noContent(201);
+	}
+
+	public function update(WordbookRequest $request, Wordbook $wordbook)
+	{
+		$this->updateWordbookUseCase->execute($wordbook->id, $request->all());
+		return response()->noContent();
+	}
+
+	public function destroy(Wordbook $wordbook)
+	{
+		$this->deleteWordbookUseCase->execute($wordbook->id);
+		return response()->noContent();
 	}
 }

--- a/backend/app/Interfaces/WordbookRepositoryInterface.php
+++ b/backend/app/Interfaces/WordbookRepositoryInterface.php
@@ -14,4 +14,8 @@ interface WordbookRepositoryInterface
 	public function getRandomWords(Wordbook $wordbook, int $count): Collection;
 
 	public function create(array $data): Wordbook;
+
+	public function update(Wordbook $wordbook, array $data): Wordbook;
+
+	public function delete(Wordbook $wordbook): void;
 }

--- a/backend/app/Repositories/WordbookRepository.php
+++ b/backend/app/Repositories/WordbookRepository.php
@@ -27,4 +27,15 @@ class WordbookRepository implements WordbookRepositoryInterface
 	{
 		return Wordbook::create($data);
 	}
+
+	public function update(Wordbook $wordbook, array $data): Wordbook
+	{
+		$wordbook->update($data);
+		return $wordbook;
+	}
+
+	public function delete(Wordbook $wordbook): void
+	{
+		$wordbook->delete();
+	}
 }

--- a/backend/app/UseCases/Admin/DeleteWordbookUseCase.php
+++ b/backend/app/UseCases/Admin/DeleteWordbookUseCase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\UseCases\Admin;
+
+use App\Interfaces\WordbookRepositoryInterface;
+
+class DeleteWordbookUseCase
+{
+	public function __construct(
+		private WordbookRepositoryInterface $wordbookRepository,
+	) {
+	}
+
+	public function execute(int $id): void
+	{
+		$wordbook = $this->wordbookRepository->find($id);
+		$this->wordbookRepository->delete($wordbook);
+	}
+}

--- a/backend/app/UseCases/Admin/UpdateWordbookUseCase.php
+++ b/backend/app/UseCases/Admin/UpdateWordbookUseCase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\UseCases\Admin;
+
+use App\Interfaces\WordbookRepositoryInterface;
+
+class UpdateWordbookUseCase
+{
+	public function __construct(
+		private WordbookRepositoryInterface $wordbookRepository,
+	) {
+	}
+
+	public function execute(int $id, array $data): void
+	{
+		$wordbook = $this->wordbookRepository->find($id);
+		$this->wordbookRepository->update($wordbook, $data);
+	}
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -35,4 +35,6 @@ Route::middleware('auth:sanctum')->prefix('admin')->name('api.admin.')->group(fu
     Route::delete('/words/{word}', [AdminWordController::class, 'destroy'])->name('words.destroy');
     Route::get('/wordbooks', [AdminWordbookController::class, 'index'])->name('wordbooks.index');
     Route::post('/wordbooks', [AdminWordbookController::class, 'store'])->name('wordbooks.store');
+    Route::put('/wordbooks/{wordbook}', [AdminWordbookController::class, 'update'])->name('wordbooks.update');
+    Route::delete('/wordbooks/{wordbook}', [AdminWordbookController::class, 'destroy'])->name('wordbooks.destroy');
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { Route, Routes } from 'react-router-dom'
 import AdminRoute from './components/AdminRoute'
 import AdminWordbookCreate from './components/AdminWordbookCreate'
+import AdminWordbookEdit from './components/AdminWordbookEdit'
 import AdminWordbookSelect from './components/AdminWordbookSelect'
 import AdminWordCreate from './components/AdminWordCreate'
 import AdminWordEdit from './components/AdminWordEdit'
@@ -20,6 +21,7 @@ function App() {
         <Route path="/admin" element={<AdminRoute />}>
           <Route path="words" element={<AdminWordList />} />
           <Route path="wordbooks/add" element={<AdminWordbookCreate />} />
+          <Route path="wordbooks/:id/edit" element={<AdminWordbookEdit />} />
           <Route path="words/create-wordbook" element={<AdminWordbookSelect />} />
           <Route path="words/create-wordbook/:wordbookId" element={<AdminWordCreate />} />
           <Route path="words/:id/edit" element={<AdminWordEdit />} />

--- a/frontend/src/api/adminWordbooks.ts
+++ b/frontend/src/api/adminWordbooks.ts
@@ -1,4 +1,4 @@
-import type { CreateWordbookPayload, WordbookListResponse } from '../types/wordbook'
+import type { CreateWordbookPayload, UpdateWordbookPayload, WordbookListResponse } from '../types/wordbook'
 import { adminFetch } from './httpClient'
 
 export async function fetchAdminWordbooks(): Promise<WordbookListResponse> {
@@ -22,5 +22,29 @@ export async function createAdminWordbook(payload: CreateWordbookPayload): Promi
 
   if (!res.ok) {
     throw new Error('単語帳の登録に失敗しました。')
+  }
+}
+
+export async function updateAdminWordbook(id: number, payload: UpdateWordbookPayload): Promise<void> {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL
+  const res = await adminFetch(`${baseUrl}/admin/wordbooks/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+
+  if (!res.ok) {
+    throw new Error('単語帳の更新に失敗しました。')
+  }
+}
+
+export async function deleteAdminWordbook(id: number): Promise<void> {
+  const baseUrl = import.meta.env.VITE_API_BASE_URL
+  const res = await adminFetch(`${baseUrl}/admin/wordbooks/${id}`, {
+    method: 'DELETE',
+  })
+
+  if (!res.ok) {
+    throw new Error('単語帳の削除に失敗しました。')
   }
 }

--- a/frontend/src/components/AdminWordbookEdit.tsx
+++ b/frontend/src/components/AdminWordbookEdit.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState, type FormEvent } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { fetchAdminWordbooks, updateAdminWordbook } from '../api/adminWordbooks'
+
+function AdminWordbookEdit() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+
+  const [name, setName] = useState('')
+
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id) return
+
+    let ignore = false
+
+    setLoading(true)
+    setError(null)
+
+    fetchAdminWordbooks()
+      .then((response) => {
+        if (ignore) return
+        const wordbook = response.data.find((item) => item.id === Number(id))
+        if (!wordbook) {
+          setError('単語帳が見つかりませんでした。')
+          return
+        }
+        setName(wordbook.name)
+      })
+      .catch(() => {
+        if (ignore) return
+        setError('単語帳の取得に失敗しました。')
+      })
+      .finally(() => {
+        if (ignore) return
+        setLoading(false)
+      })
+
+    return () => {
+      ignore = true
+    }
+  }, [id])
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (submitting || !id) return
+
+    setSubmitting(true)
+    setSubmitError(null)
+
+    updateAdminWordbook(Number(id), { name })
+      .then(() => {
+        navigate('/admin/words/create-wordbook')
+      })
+      .catch(() => {
+        setSubmitError('単語帳の更新に失敗しました。')
+      })
+      .finally(() => {
+        setSubmitting(false)
+      })
+  }
+
+  return (
+    <div className="min-h-screen bg-white px-4 py-10">
+      <div className="mx-auto max-w-3xl">
+        <div className="mb-6 border-b-4 border-green-500 pb-2">
+          <Link to="/admin/words/create-wordbook" className="text-sm text-green-600 hover:underline">
+            ← 単語帳一覧へ戻る
+          </Link>
+          <h1 className="mt-2 text-3xl font-bold text-gray-900">単語帳を編集</h1>
+        </div>
+
+        {loading && <p className="text-gray-500">読み込み中...</p>}
+
+        {!loading && error && (
+          <p role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+            {error}
+          </p>
+        )}
+
+        {!loading && !error && (
+          <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-gray-200 p-6 shadow-sm">
+            <div className="flex items-center gap-3">
+              <label htmlFor="name" className="w-20 shrink-0 text-sm font-medium text-gray-700">
+                単語帳名
+              </label>
+              <input
+                id="name"
+                type="text"
+                required
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+              />
+            </div>
+
+            {submitError && (
+              <p role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+                {submitError}
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full rounded-md bg-green-600 px-4 py-2 text-sm font-medium text-white hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
+            >
+              {submitting ? '更新中...' : '更新する'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default AdminWordbookEdit

--- a/frontend/src/components/AdminWordbookSelect.tsx
+++ b/frontend/src/components/AdminWordbookSelect.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { fetchAdminWordbooks } from '../api/adminWordbooks'
+import { deleteAdminWordbook, fetchAdminWordbooks } from '../api/adminWordbooks'
 import type { Wordbook } from '../types/wordbook'
 
 function AdminWordbookSelect() {
   const [wordbooks, setWordbooks] = useState<Wordbook[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+
+  const [deletingId, setDeletingId] = useState<number | null>(null)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
 
   useEffect(() => {
     let ignore = false
@@ -33,6 +36,26 @@ function AdminWordbookSelect() {
     }
   }, [])
 
+  const handleDelete = (id: number) => {
+    if (deletingId !== null) return
+    if (!window.confirm('この単語帳を削除しますか？')) return
+
+    setDeletingId(id)
+    setDeleteError(null)
+
+    deleteAdminWordbook(id)
+      .then(() => fetchAdminWordbooks())
+      .then((response) => {
+        setWordbooks(response.data)
+      })
+      .catch(() => {
+        setDeleteError('単語帳の削除に失敗しました。')
+      })
+      .finally(() => {
+        setDeletingId(null)
+      })
+  }
+
   return (
     <div className="min-h-screen bg-white px-4 py-10">
       <div className="mx-auto max-w-3xl">
@@ -54,21 +77,45 @@ function AdminWordbookSelect() {
           </p>
         )}
 
-        {!loading && !error && wordbooks.length === 0 && <p className="text-gray-700">単語帳がありません。</p>}
+        {!loading && !error && (
+          <>
+            {deleteError && (
+              <p role="alert" className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+                {deleteError}
+              </p>
+            )}
 
-        {!loading && !error && wordbooks.length > 0 && (
-          <ul className="divide-y divide-gray-100 overflow-hidden rounded-lg border border-gray-200 shadow-sm">
-            {wordbooks.map((wordbook) => (
-              <li key={wordbook.id}>
-                <Link
-                  to={`/admin/words/create-wordbook/${wordbook.id}`}
-                  className="block px-4 py-3 font-medium text-gray-900 hover:bg-green-50 hover:text-green-600"
-                >
-                  {wordbook.name}
-                </Link>
-              </li>
-            ))}
-          </ul>
+            {wordbooks.length === 0 && <p className="text-gray-700">単語帳がありません。</p>}
+
+            {wordbooks.length > 0 && (
+              <ul className="divide-y divide-gray-100 overflow-hidden rounded-lg border border-gray-200 shadow-sm">
+                {wordbooks.map((wordbook) => (
+                  <li key={wordbook.id} className="flex items-center justify-between gap-3 px-4 py-3 hover:bg-green-50">
+                    <Link
+                      to={`/admin/words/create-wordbook/${wordbook.id}`}
+                      className="flex-1 font-medium text-gray-900 hover:text-green-600"
+                    >
+                      {wordbook.name}
+                    </Link>
+                    <Link
+                      to={`/admin/wordbooks/${wordbook.id}/edit`}
+                      className="rounded-md bg-green-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-700"
+                    >
+                      編集
+                    </Link>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(wordbook.id)}
+                      disabled={deletingId === wordbook.id}
+                      className="rounded-md bg-red-500 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-600 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
+                    >
+                      {deletingId === wordbook.id ? '削除中...' : '削除'}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -36,6 +36,11 @@ function Header() {
                 管理
               </Link>
             </li>
+            <li>
+              <Link to="/admin/words/create-wordbook" className="text-gray-700 hover:text-green-600">
+                単語帳一覧
+              </Link>
+            </li>
             {isAuthenticated && (
               <li>
                 <button type="button" onClick={handleLogout} className="text-gray-700 hover:text-green-600">

--- a/frontend/src/types/wordbook.ts
+++ b/frontend/src/types/wordbook.ts
@@ -10,3 +10,7 @@ export interface WordbookListResponse {
 export interface CreateWordbookPayload {
   name: string
 }
+
+export interface UpdateWordbookPayload {
+  name: string
+}


### PR DESCRIPTION
## 概要

- Issue #58 として、単語帳の名前編集・削除機能をバックエンドAPI・React画面の両方に実装

## 主な実装

- **`WordbookRepositoryInterface` / `WordbookRepository`**：`update`・`delete`メソッドを追加。既存の`WordRepository`と同一パターン
- **`UpdateWordbookUseCase` / `DeleteWordbookUseCase`**（新規）：`find`→`update`／`find`→`delete`のシンプルな構成。`UpdateWordUseCase`・`DeleteWordUseCase`と同一構成
- **`Api/Admin/WordbookController`**：`update(WordbookRequest, Wordbook)`・`destroy(Wordbook)`を追加。Route Model Bindingにより存在しないIDは自動的に404
- **`routes/api.php`**：`PUT /admin/wordbooks/{wordbook}`（`wordbooks.update`）・`DELETE /admin/wordbooks/{wordbook}`（`wordbooks.destroy`）を`auth:sanctum`ミドルウェア配下に追加
- **`frontend/src/api/adminWordbooks.ts`**：`updateAdminWordbook(id, payload)`・`deleteAdminWordbook(id)`を追加
- **`frontend/src/types/wordbook.ts`**：`UpdateWordbookPayload`を追加
- **`frontend/src/components/AdminWordbookEdit.tsx`**（新規）：`AdminWordbookCreate.tsx`をベースに、初期値は既存の`fetchAdminWordbooks()`をURLの`id`でフィルタして表示
- **`frontend/src/components/AdminWordbookSelect.tsx`**：各行に「編集」リンクと「削除」ボタンを追加。`AdminWordList.tsx`の削除確認パターンを踏襲
- **`frontend/src/App.tsx`**：`wordbooks/:id/edit`ルートを追加
- **`frontend/src/components/Header.tsx`**：グローバルメニューに「単語帳一覧」へのリンクを追加

## 本PR対象外

- 単語帳に単語が含まれる場合の削除確認・警告UIの具体的なデザイン
- 単語帳の並び替え機能
- 単語帳1件取得用の新規GETエンドポイント（一覧取得を流用）
- グローバルメニューへの「単語帳追加」リンク追加（一覧ページのボタンで代替）

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] `PUT /api/admin/wordbooks/{wordbook}` で単語帳の名前を更新できる
- [ ] `DELETE /api/admin/wordbooks/{wordbook}` で単語帳を削除できる
- [ ] 単語帳を削除すると、中間テーブル`wordbook_word`の関連レコードも削除される（外部キーの`cascade`設定を利用、単語自体は削除されない）
- [ ] 存在しない単語帳IDを指定すると404が返る（PUT/DELETE共通）
- [ ] 未認証でアクセスすると401が返る（PUT/DELETE共通）
- [ ] React側（管理 単語帳選択ページ等）から単語帳の名前編集・削除を操作できる

### リグレッション確認

- [ ] 単語追加・単語一覧など既存機能に影響がない

Closes #58
