### PR TITLE
refactor: React SPA移行済みの旧Bladeルートを削除

### DIFF
--- a/backend/resources/views/index.blade.php
+++ b/backend/resources/views/index.blade.php
@@ -8,7 +8,7 @@
   <div class="container">
     <h2>単語一覧ページ</h2>
     <!-- 単語帳選択と検索フォーム -->
-    <form action="{{ route('create') }}" method="GET">
+    <form action="{{ route('index') }}" method="GET">
       <div class="inner__text">
         <label for="wordbook">単語帳を選択</label>
         <select name="wordbook_id" id="wordbook" onchange="this.form.submit()">

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\HomeController;
-use App\Http\Controllers\AdminController;
 
 /*
 |--------------------------------------------------------------------------
@@ -19,16 +18,3 @@ use App\Http\Controllers\AdminController;
 Route::get('/', [HomeController::class, 'index'])->name('index');
 Route::get('/test', [HomeController::class, 'test'])->name('test');
 Route::post('/test', [HomeController::class, 'startTest'])->name('test.start');
-
-
-
-Route::middleware(['auth'])->group(function () {
-  Route::get('/list', [AdminController::class, 'list'])->name('list');
-  Route::get('/edit/{id}', [AdminController::class, 'edit'])->name('edit');
-  Route::put('/edit/{id}', [AdminController::class, 'update'])->name('update');
-  Route::get('/create-wordbook', [AdminController::class, 'selectWordbook'])->name('create.wordbook');
-  Route::get('/create', [AdminController::class, 'create'])->name('create');
-  Route::post('/create', [AdminController::class, 'store'])->name('store');
-  Route::get('/add', [AdminController::class, 'add'])->name('add');
-  Route::post('/add', [AdminController::class, 'books'])->name('books');
-  });


### PR DESCRIPTION
## 概要

- Issue #59 として、React SPAへの移行が完了した管理画面に対応する旧Bladeルートを`routes/web.php`から削除
- Bladeビューファイル自体は今回削除せず残す方針（Issue対象外）

## 主な実装

- **`backend/routes/web.php`**：`auth`ミドルウェアグループ内の`/list`・`/edit/{id}`（GET/PUT）・`/create-wordbook`・`/create`（GET/POST）・`/add`（GET/POST）ルート定義と、中身が空になる`auth`グループのラッパー、不要になった`AdminController`の`use`文を削除
- **`backend/resources/views/index.blade.php`**：単語一覧ページ（`/`）の検索フォームが参照していた`route('create')`を、削除しても残る既存の`route('index')`へ差し替え。このフォームは`ListWordsUseCase`がクエリパラメータを未参照のため元々絞り込み機能を持たない実装だったため、見た目・挙動は変えていない

## Figma / 設計書との差異・補足

- Issueの制約は「変更対象は`routes/web.php`のルート定義のみ」だが、`create`ルート削除により`index.blade.php`内の`route('create')`呼び出しが解決できず`/`ページが`RouteNotFoundException`で表示できなくなることが判明したため、`/analyze`時点で人間の承認を得たうえで`index.blade.php`の該当1行のみ修正範囲に追加した

## 本PR対象外

- Bladeビューファイル（テンプレート）自体の削除
- `AdminController`のメソッド自体の削除
- `index.blade.php`の検索・単語帳フィルタ機能自体の実装（現状どおり非機能のまま）

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [x] `routes/web.php`から、React SPA移行済み機能に対応するBladeルート定義を削除する
- [x] 対応するBladeビューファイル（`.blade.php`）自体は削除せず残す
- [ ] ルート削除後も、Reactアプリ・既存の公開ページ（`/`・`/test`）・ログイン（`/login`）が問題なく動作する

### リグレッション確認

- [ ] `/`にアクセスし、単語一覧・単語帳選択欄・検索欄が従来どおり表示される
- [ ] `/test`のテスト開始フォームが従来どおり動作する
- [ ] `/login`からのログイン・ログアウトが従来どおり動作する
- [ ] Reactの管理画面（単語一覧・単語追加・単語編集・単語帳追加・単語帳編集）が従来どおり操作できる
- [ ] `php artisan route:list`で、削除対象ルートが一覧から消えている

Closes #59
