### PR TITLE
chore: 本番環境（ロリポップ）への初回デプロイ対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ frontend/.env
 frontend/.env.local
 frontend/.env.*.local
 
+# React SPAビルド成果物（Laravel publicへ出力）
+backend/public/spa/
+
 # Codex
 .agents/
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,6 +5,9 @@ APP_DEBUG=true
 APP_URL=http://localhost
 FRONTEND_URL=http://localhost:3000
 
+ADMIN_EMAIL=
+ADMIN_PASSWORD=
+
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug

--- a/backend/config/app.php
+++ b/backend/config/app.php
@@ -214,4 +214,18 @@ return [
         // 'ExampleClass' => App\Example\ExampleClass::class,
     ])->toArray(),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Admin Seeder Credentials
+    |--------------------------------------------------------------------------
+    |
+    | DatabaseSeederが作成する管理者アカウントのemail・passwordです。
+    | 秘密情報のため、コードへハードコードせず.envで管理します。
+    |
+    */
+
+    'admin_email' => env('ADMIN_EMAIL'),
+
+    'admin_password' => env('ADMIN_PASSWORD'),
+
 ];

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Seeder;
 use App\Models\Wordbook;
 use App\Models\Word;
 use App\Models\User;
+use RuntimeException;
 
 class DatabaseSeeder extends Seeder
 {
@@ -15,9 +16,16 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
+      $adminEmail = config('app.admin_email');
+      $adminPassword = config('app.admin_password');
+
+      if (! $adminEmail || ! $adminPassword) {
+        throw new RuntimeException('ADMIN_EMAIL and ADMIN_PASSWORD must be set in .env before seeding.');
+      }
+
       User::create([
-        'email' => 'admin@example.com',
-        'password' => bcrypt('password'),
+        'email' => $adminEmail,
+        'password' => bcrypt($adminPassword),
       ]);
 			Wordbook::create([
         'name' => 'ターゲット1200'

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,7 +1,7 @@
 <?php
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\HomeController;
 
 /*
 |--------------------------------------------------------------------------
@@ -14,7 +14,10 @@ use App\Http\Controllers\HomeController;
 |
 */
 
+Route::fallback(function (Request $request) {
+    if ($request->is('api/*')) {
+        return response()->json(['message' => 'Not Found.'], 404);
+    }
 
-Route::get('/', [HomeController::class, 'index'])->name('index');
-Route::get('/test', [HomeController::class, 'test'])->name('test');
-Route::post('/test', [HomeController::class, 'startTest'])->name('test.start');
+    return response()->file(public_path('spa/index.html'));
+});

--- a/docs/development/deploy.md
+++ b/docs/development/deploy.md
@@ -1,0 +1,110 @@
+# 本番環境（ロリポップ）への初回デプロイ手順
+
+対象: Issue #57
+
+前提: ロリポップのSSH接続・Composerの実行が可能なプランを契約済みであること。ファイル配置はSSH経由の`git pull`で行う。
+
+フロントエンド（React）とバックエンド（Laravel API）は、完全に同一オリジンで運用する。Laravelが`backend/public/`配下でAPIレスポンスとReactの静的ビルド成果物の両方を配信する。
+
+## 1. サーバー側の前提確認
+
+- [ ] 契約ドメインのドキュメントルートを`backend/public`配下に設定できること
+- [ ] 本番用MySQLデータベース（ホスト・DB名・ユーザー・パスワード）をロリポップの管理画面で作成済みであること
+- [ ] SSH接続情報を確認済みであること
+
+## 2. リポジトリの取得
+
+```bash
+ssh <ロリポップのSSHユーザー>@<ホスト>
+cd <ドキュメントルートの配置先>
+git clone <リポジトリURL> .
+git switch main
+```
+
+## 3. バックエンドのセットアップ
+
+```bash
+cd backend
+composer install --no-dev --optimize-autoloader
+cp .env.example .env
+php artisan key:generate
+```
+
+`.env`に本番用の値を設定する。
+
+```dotenv
+APP_NAME=英単語帳アプリ
+APP_ENV=production
+APP_DEBUG=false
+APP_URL=https://<本番ドメイン>
+FRONTEND_URL=https://<本番ドメイン>
+
+DB_CONNECTION=mysql
+DB_HOST=<ロリポップのDBホスト>
+DB_PORT=3306
+DB_DATABASE=<ロリポップで作成したDB名>
+DB_USERNAME=<DBユーザー名>
+DB_PASSWORD=<DBパスワード>
+
+ADMIN_EMAIL=<本番用の管理者email>
+ADMIN_PASSWORD=<本番用の管理者password>
+
+SESSION_SECURE_COOKIE=true
+SANCTUM_STATEFUL_DOMAINS=<本番ドメイン（ポートなし）>
+```
+
+`FRONTEND_URL`と`APP_URL`は同一オリジン構成のため同じドメインを指定する。
+
+秘密情報を含む本番用`.env`はコミットしない。
+
+## 4. マイグレーション・初期データ投入
+
+```bash
+php artisan migrate --force
+php artisan db:seed --force
+```
+
+`db:seed`は初回のみ実行する。`ADMIN_EMAIL`・`ADMIN_PASSWORD`が`.env`に設定されていない場合はエラーで停止する。
+
+## 5. フロントエンドのビルド
+
+```bash
+cd ../frontend
+npm install
+cp .env.example .env
+```
+
+`.env`の`VITE_API_BASE_URL`を同一オリジンの相対パスに設定する。
+
+```dotenv
+VITE_API_BASE_URL=/api
+```
+
+```bash
+npm run build
+```
+
+`vite.config.ts`の設定により、ビルド成果物は`backend/public/spa/`へ直接出力される。
+
+## 6. 動作確認
+
+- [ ] `https://<本番ドメイン>/`でReactの単語一覧が表示される
+- [ ] `https://<本番ドメイン>/test`でクイズ機能が動作する
+- [ ] `/admin/words`などを直接URL入力・リロードしても404にならない
+- [ ] `/login`でBladeログイン画面が表示され、ログイン後`/admin/words`へ遷移しCRUD操作ができる
+- [ ] 存在しないAPIパス（例：`/api/does-not-exist`）がJSON形式の404を返す
+- [ ] 未認証で管理ページにアクセスすると`/login`にリダイレクトされる
+- [ ] `.env`・ビルド成果物に秘密情報が含まれず、リポジトリへコミットされていない
+
+## 今後の更新デプロイ
+
+初回リリース後にコードを更新する場合は、サーバー上で以下を実行する。
+
+```bash
+git pull origin main
+cd backend && composer install --no-dev --optimize-autoloader
+php artisan migrate --force
+cd ../frontend && npm install && npm run build
+```
+
+CI/CDによる自動デプロイは対象外（Issue #57の対象外事項）。

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,8 +2,8 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
-export default defineConfig({
-  base: '/spa/',
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/spa/' : '/',
   plugins: [react(), tailwindcss()],
   server: {
     host: '0.0.0.0',
@@ -13,4 +13,4 @@ export default defineConfig({
     outDir: '../backend/public/spa',
     emptyOutDir: true,
   },
-})
+}))

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,9 +3,14 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
+  base: '/spa/',
   plugins: [react(), tailwindcss()],
   server: {
     host: '0.0.0.0',
     port: 3000,
+  },
+  build: {
+    outDir: '../backend/public/spa',
+    emptyOutDir: true,
   },
 })


### PR DESCRIPTION
## 概要

- Issue #57 として、ロリポップ本番環境へのLaravel API + React SPA初回デプロイに向けたコード対応を実施
- フロントエンドとバックエンドは完全に同一オリジンで運用する構成とし、Laravelが`backend/public/`配下でAPIレスポンスとReact静的ビルド成果物の両方を配信する

## 主な実装

- **backend/routes/web.php**：旧Blade用の`/`・`/test`ルート（`HomeController`参照）を削除し、`Route::fallback()`を追加。`/api/*`以外の未一致リクエストにはReactのビルド済み`index.html`を返し、`/api/*`はJSON形式の404を返す
- **backend/config/app.php・backend/database/seeders/DatabaseSeeder.php**：管理者アカウントのemail/passwordのハードコードを解消し、`.env`の`ADMIN_EMAIL`/`ADMIN_PASSWORD`から読み込むよう変更。未設定時は例外で停止する。`Wordbook`・`Word`作成部分は変更なし
- **backend/.env.example**：`ADMIN_EMAIL`・`ADMIN_PASSWORD`のキーを追加（値は空）
- **frontend/vite.config.ts**：本番ビルド時のみ`base: '/spa/'`を適用し、ビルド成果物を`backend/public/spa/`へ直接出力するよう変更。開発サーバー実行時は従来通り`base: '/'`のまま維持し、ローカル開発環境への影響がないことを確認済み
- **.gitignore**：ビルド成果物`backend/public/spa/`を除外（既存の`frontend/dist/`除外と同じ考え方）
- **docs/development/deploy.md**：ロリポップへの初回デプロイ手順書を新規作成（SSH経由のgit pull前提、本番`.env`設定値、動作確認チェックリストなど）

## Figma / 設計書との差異・補足

- フロントエンドとバックエンドを完全に同一オリジンで運用する方針とした。これによりCookieベースのセッション認証（Sanctum + Fortify）を無改修で利用でき、CORS・SameSite関連の追加実装が不要になる
- 実際のロリポップサーバー操作（SSH接続、`composer install`、`migrate`、`db:seed`の実行、ドキュメントルート設定など）は、本番DBへの破壊的操作を伴うため本PRには含まず、`docs/development/deploy.md`の手順に沿って人間が手動で実施する

## 本PR対象外

- 会員登録機能の追加
- CI/CDによる自動デプロイの構築
- ユーザーごとのデータ分離（マルチユーザー対応）
- 実際のロリポップサーバーへのデプロイ作業そのもの（手順書に基づき人間が実施）

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] ロリポップ上でLaravel APIが動作する（`APP_ENV=production`・`APP_DEBUG=false`を設定）
- [ ] フロントエンド（React）の本番ビルドがロリポップ上で静的ホスティングされ、SPAとして正しく動作する（ページ遷移・リロード時の404を含めて確認する）
- [ ] フロントエンドから本番のLaravel APIへ通信できる（CORS・APIベースURLの設定を含む）
- [ ] 本番用DBにマイグレーションが適用されている
- [x] `DatabaseSeeder`が管理者アカウントのemail・passwordを`.env`の環境変数から読み込み、ソースコードにハードコードされていない
- [x] `.env.example`に該当キーを追加する（値はダミーまたは空とし、実際の秘密値は含めない）
- [ ] 本番環境で単語一覧・クイズ機能など既存の主要機能が動作する
- [ ] 本番用の`.env`・ビルド時環境変数に秘密情報が含まれず、リポジトリへコミットされていない

### リグレッション確認

- [x] ローカル開発環境（Docker Compose、`http://localhost:3000`）でフロントエンドが従来通り動作することを確認済み
- [ ] 本番環境（ロリポップ）での既存機能への影響確認（デプロイ後に実施）

Closes #57
