### PR TITLE
docs: ロリポップ初回デプロイ手順書を実態に合わせて修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ backend/public/spa/
 # Codex
 .agents/
 
+# ロリポップ実デプロイ用手順メモ（秘密情報を含むためコミットしない）
+docs/development/deploy-local.md
+
 # OS
 .DS_Store
 Thumbs.db

--- a/docs/development/deploy.md
+++ b/docs/development/deploy.md
@@ -18,7 +18,7 @@
 ssh <ロリポップのSSHユーザー>@<ホスト>
 cd <ドキュメントルートの配置先>
 git clone <リポジトリURL> .
-git switch main
+git switch develop
 ```
 
 ## 3. バックエンドのセットアップ
@@ -66,10 +66,12 @@ php artisan db:seed --force
 
 `db:seed`は初回のみ実行する。`ADMIN_EMAIL`・`ADMIN_PASSWORD`が`.env`に設定されていない場合はエラーで停止する。
 
-## 5. フロントエンドのビルド
+## 5. フロントエンドのビルド（ローカル環境で実行）
+
+ロリポップにはNode.js/npmの実行環境がないため、フロントエンドは開発者のローカル環境でビルドし、ビルド成果物を`scp`でサーバーへ転送する。
 
 ```bash
-cd ../frontend
+cd frontend
 npm install
 cp .env.example .env
 ```
@@ -84,27 +86,40 @@ VITE_API_BASE_URL=/api
 npm run build
 ```
 
-`vite.config.ts`の設定により、ビルド成果物は`backend/public/spa/`へ直接出力される。
+`vite.config.ts`の設定により、ビルド成果物はローカルの`backend/public/spa/`へ出力される。これをロリポップサーバーへ転送する。
+
+```bash
+scp -r backend/public/spa <ロリポップのSSHユーザー>@<ホスト>:<ドキュメントルートの配置先>/backend/public/spa
+```
 
 ## 6. 動作確認
 
 - [ ] `https://<本番ドメイン>/`でReactの単語一覧が表示される
 - [ ] `https://<本番ドメイン>/test`でクイズ機能が動作する
-- [ ] `/admin/words`などを直接URL入力・リロードしても404にならない
-- [ ] `/login`でBladeログイン画面が表示され、ログイン後`/admin/words`へ遷移しCRUD操作ができる
+- [ ] `/admin/words/create-wordbook`などを直接URL入力・リロードしても404にならない
+- [ ] `/login`でBladeログイン画面が表示され、ログイン後`/`へ遷移しCRUD操作ができる
 - [ ] 存在しないAPIパス（例：`/api/does-not-exist`）がJSON形式の404を返す
 - [ ] 未認証で管理ページにアクセスすると`/login`にリダイレクトされる
 - [ ] `.env`・ビルド成果物に秘密情報が含まれず、リポジトリへコミットされていない
 
 ## 今後の更新デプロイ
 
-初回リリース後にコードを更新する場合は、サーバー上で以下を実行する。
+初回リリース後にコードを更新する場合は、次の手順で行う。
+
+サーバー上（バックエンドのみ）：
 
 ```bash
-git pull origin main
+git pull origin develop
 cd backend && composer install --no-dev --optimize-autoloader
 php artisan migrate --force
-cd ../frontend && npm install && npm run build
+```
+
+フロントエンドはロリポップにNode.js/npmがないため、ローカル環境でビルドし`scp`で転送する（手順は「5. フロントエンドのビルド」と同じ）。
+
+```bash
+# ローカル環境で実行
+cd frontend && npm install && npm run build
+scp -r backend/public/spa <ロリポップのSSHユーザー>@<ホスト>:<ドキュメントルートの配置先>/backend/public/spa
 ```
 
 CI/CDによる自動デプロイは対象外（Issue #57の対象外事項）。


### PR DESCRIPTION
## 概要

- Issue #65 として、`docs/development/deploy.md`の記載を実際のロリポップ環境に合わせて修正
- あわせて、実際の接続情報を含む`docs/development/deploy-local.md`（非公開・ローカル専用）を作成

## 主な実装

- **`docs/development/deploy.md`**：
  - 「2. リポジトリの取得」の基準ブランチを`main`から`develop`に修正
  - 「5. フロントエンドのビルド」を、ロリポップにNode.js/npmが存在しない前提のローカルビルド＋`scp`転送方式に修正
  - 「今後の更新デプロイ」節も、サーバー側（`git pull`・`composer install`・`migrate`）とローカル側（フロントエンドビルド＋`scp`転送）に分けて修正
  - 「6. 動作確認」の`/admin/words`関連記載を、Issue #67（PR #69）による`/admin/words`ルート削除・ログイン後遷移先変更（`/`）に合わせて修正
- **`.gitignore`**：`docs/development/deploy-local.md`を追加し、実際の接続情報がリポジトリへコミットされないようにした

## Figma / 設計書との差異・補足

- 承認済み実装方針にはなかった「6. 動作確認」の`/admin/words`関連記載修正を、Issue #65の目的（`deploy.md`を実態に合わせる）に不可欠な範囲として含めた（Issueコメントの実装方針にも明記し承認済み）

## 本PR対象外

- サーバー側での実際のSSH接続・scp実行などの実作業（本PRはドキュメントのみの修正）
- `deploy.md`・`deploy-local.md`以外のドキュメント修正

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [x] `docs/development/deploy.md`「2. リポジトリの取得」の基準ブランチが`main`から`develop`に修正されている
- [x] `docs/development/deploy.md`「5. フロントエンドのビルド」が、ロリポップにNode.js/npmが存在しないことを前提に、ローカルビルド＋転送（scp）方式に修正されている
- [x] `docs/development/deploy.md`「今後の更新デプロイ」節も同様に`develop`基準・ローカルビルド方式に修正されている
- [x] `docs/development/deploy-local.md`（実際のドメイン・パス等を含む手順メモ）を作成し、`.gitignore`へ追加してGitHubにコミットされないようにする

### リグレッション確認

- [x] `backend/`・`frontend/`配下のコードに変更がないことを確認済み

Closes #65
