### PR TITLE
feat: 単語追加成功後、同じ単語帳の単語追加ページへ留まるよう変更

### DIFF
--- a/frontend/src/components/AdminWordCreate.tsx
+++ b/frontend/src/components/AdminWordCreate.tsx
@@ -35,7 +35,6 @@ function AdminWordCreate() {
         setJapanese('')
         setPartOfSpeech('')
         setOrder('')
-        setSubmitError(null)
       })
       .catch(() => {
         setSubmitError('単語の登録に失敗しました。')

--- a/frontend/src/components/AdminWordCreate.tsx
+++ b/frontend/src/components/AdminWordCreate.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
 import { createAdminWord } from '../api/adminWords'
 import { PART_OF_SPEECH_BADGE_STYLES, type PartOfSpeech } from '../types/word'
 
@@ -7,7 +7,6 @@ const PART_OF_SPEECH_OPTIONS: PartOfSpeech[] = ['名詞', '動詞', '形容詞',
 
 function AdminWordCreate() {
   const { wordbookId } = useParams<{ wordbookId: string }>()
-  const navigate = useNavigate()
 
   const [english, setEnglish] = useState('')
   const [japanese, setJapanese] = useState('')
@@ -32,7 +31,11 @@ function AdminWordCreate() {
       order: Number(order),
     })
       .then(() => {
-        navigate('/')
+        setEnglish('')
+        setJapanese('')
+        setPartOfSpeech('')
+        setOrder('')
+        setSubmitError(null)
       })
       .catch(() => {
         setSubmitError('単語の登録に失敗しました。')


### PR DESCRIPTION
## 概要

- Issue #75 として、単語追加ページ（`AdminWordCreate.tsx`）での単語登録成功後の遷移先を、単語一覧（`/`）から、同じ単語帳の単語追加ページ（`/admin/words/create-wordbook/:wordbookId`）へ留まる形に変更した
- 同じ単語帳へ連続して単語を追加する運用を想定した変更

## 主な実装

- **`frontend/src/components/AdminWordCreate.tsx`**：登録成功時の`navigate('/')`を削除し、`english`・`japanese`・`partOfSpeech`・`order`を初期値へリセットする処理に置き換えた。React Routerは同一URLへの`navigate`ではコンポーネントを再マウントせず、stateも自動リセットされないため、遷移ではなく明示的なstateリセットで対応している。未使用となった`useNavigate`のimportと`navigate`変数も削除した

## 本PR対象外

- 単語一覧ページ（WordList.tsx）の変更
- 単語帳選択ページ（AdminWordbookSelect.tsx）の変更
- 別の単語帳への切り替え導線の追加
- 登録成功時の視覚的フィードバック（トースト等）の追加

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] 単語帳を選択して単語追加ページから単語を登録すると、登録完了後、同じ`wordbookId`を維持したまま単語追加ページへ遷移する
- [ ] 遷移後、フォームの入力内容（英単語・日本語・品詞・No）は初期状態（空）に戻っている
- [ ] 単語一覧ページへの「戻る」導線は引き続き表示され、クリックすると単語一覧へ遷移する

### リグレッション確認

- [ ] 単語一覧ページ・単語帳選択ページの挙動に影響がない

Closes #75
