### PR TITLE
feat: 単語一覧ページの表示件数を30件に変更し品詞・単語帳の絞り込み機能を追加

### DIFF
--- a/backend/app/Http/Controllers/Api/WordController.php
+++ b/backend/app/Http/Controllers/Api/WordController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\WordIndexRequest;
 use App\Http\Resources\WordResource;
 use App\UseCases\Api\Word\ListWordsUseCase;
 
@@ -13,9 +14,12 @@ class WordController extends Controller
 	) {
 	}
 
-	public function index()
+	public function index(WordIndexRequest $request)
 	{
-		$words = $this->listWordsUseCase->execute();
+		$words = $this->listWordsUseCase->execute(
+			$request->validated('part_of_speech'),
+			$request->validated('wordbook_id'),
+		);
 		return WordResource::collection($words);
 	}
 }

--- a/backend/app/Http/Requests/WordIndexRequest.php
+++ b/backend/app/Http/Requests/WordIndexRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class WordIndexRequest extends FormRequest
+{
+	/**
+	 * Determine if the user is authorized to make this request.
+	 */
+	public function authorize(): bool
+	{
+		return true;
+	}
+
+	/**
+	 * Get the validation rules that apply to the request.
+	 *
+	 * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+	 */
+	public function rules(): array
+	{
+		return [
+			'part_of_speech' => 'nullable|in:名詞,動詞,形容詞,副詞,前置詞',
+			'wordbook_id' => 'nullable|integer|exists:wordbooks,id',
+		];
+	}
+}

--- a/backend/app/Http/Resources/WordResource.php
+++ b/backend/app/Http/Resources/WordResource.php
@@ -12,7 +12,10 @@ class WordResource extends JsonResource
 	 */
 	public function toArray(Request $request): array
 	{
-		$wordbook = $this->wordbooks->first();
+		$wordbookId = $request->query('wordbook_id');
+		$wordbook = $wordbookId
+			? $this->wordbooks->firstWhere('id', (int) $wordbookId)
+			: $this->wordbooks->first();
 
 		return [
 			'id' => $this->id,

--- a/backend/app/Interfaces/WordRepositoryInterface.php
+++ b/backend/app/Interfaces/WordRepositoryInterface.php
@@ -7,7 +7,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 
 interface WordRepositoryInterface
 {
-	public function paginate(int $perPage): LengthAwarePaginator;
+	public function paginate(int $perPage, ?string $partOfSpeech = null, ?int $wordbookId = null): LengthAwarePaginator;
 
 	public function find(int $id): ?Word;
 

--- a/backend/app/Repositories/WordRepository.php
+++ b/backend/app/Repositories/WordRepository.php
@@ -8,9 +8,12 @@ use Illuminate\Pagination\LengthAwarePaginator;
 
 class WordRepository implements WordRepositoryInterface
 {
-	public function paginate(int $perPage): LengthAwarePaginator
+	public function paginate(int $perPage, ?string $partOfSpeech = null, ?int $wordbookId = null): LengthAwarePaginator
 	{
-		return Word::with('wordbooks')->paginate($perPage);
+		return Word::with('wordbooks')
+			->when($partOfSpeech, fn ($query) => $query->where('part_of_speech', $partOfSpeech))
+			->when($wordbookId, fn ($query) => $query->whereHas('wordbooks', fn ($q) => $q->where('wordbooks.id', $wordbookId)))
+			->paginate($perPage);
 	}
 
 	public function find(int $id): ?Word

--- a/backend/app/UseCases/Api/Word/ListWordsUseCase.php
+++ b/backend/app/UseCases/Api/Word/ListWordsUseCase.php
@@ -12,8 +12,8 @@ class ListWordsUseCase
 	) {
 	}
 
-	public function execute(): LengthAwarePaginator
+	public function execute(?string $partOfSpeech, ?int $wordbookId): LengthAwarePaginator
 	{
-		return $this->wordRepository->paginate(100);
+		return $this->wordRepository->paginate(30, $partOfSpeech, $wordbookId);
 	}
 }

--- a/frontend/src/api/words.ts
+++ b/frontend/src/api/words.ts
@@ -1,8 +1,16 @@
-import type { WordListResponse } from '../types/word'
+import type { PartOfSpeech, WordListResponse } from '../types/word'
 
-export async function fetchWords(page: number): Promise<WordListResponse> {
+export async function fetchWords(
+  page: number,
+  partOfSpeech?: PartOfSpeech,
+  wordbookId?: number,
+): Promise<WordListResponse> {
   const baseUrl = import.meta.env.VITE_API_BASE_URL
-  const res = await fetch(`${baseUrl}/words?page=${page}`)
+  const params = new URLSearchParams({ page: String(page) })
+  if (partOfSpeech) params.set('part_of_speech', partOfSpeech)
+  if (wordbookId) params.set('wordbook_id', String(wordbookId))
+
+  const res = await fetch(`${baseUrl}/words?${params.toString()}`)
 
   if (!res.ok) {
     throw new Error('単語一覧の取得に失敗しました。')

--- a/frontend/src/components/WordList.tsx
+++ b/frontend/src/components/WordList.tsx
@@ -30,7 +30,7 @@ function WordList() {
     fetchWordbooks()
       .then((response) => setWordbooks(response.data))
       .catch(() => {
-        // 絞り込み選択肢の取得失敗は一覧表示自体を妨げないため無視する
+        window.alert('単語帳一覧の取得に失敗しました。')
       })
   }, [])
 
@@ -61,7 +61,9 @@ function WordList() {
   }, [currentPage, partOfSpeech, wordbookId])
 
   const handlePartOfSpeechChange = (value: string) => {
-    setPartOfSpeech(value as PartOfSpeech | '')
+    const isPartOfSpeech = (candidate: string): candidate is PartOfSpeech =>
+      PART_OF_SPEECH_OPTIONS.includes(candidate as PartOfSpeech)
+    setPartOfSpeech(isPartOfSpeech(value) ? value : '')
     setCurrentPage(1)
   }
 

--- a/frontend/src/components/WordList.tsx
+++ b/frontend/src/components/WordList.tsx
@@ -1,8 +1,18 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { fetchWordbooks } from '../api/wordbooks'
 import { fetchWords } from '../api/words'
 import { useCurrentUser } from '../hooks/useCurrentUser'
-import { PART_OF_SPEECH_BADGE_STYLES, PART_OF_SPEECH_LABELS, type PaginationMeta, type Word } from '../types/word'
+import {
+  PART_OF_SPEECH_BADGE_STYLES,
+  PART_OF_SPEECH_LABELS,
+  type PaginationMeta,
+  type PartOfSpeech,
+  type Word,
+} from '../types/word'
+import type { Wordbook } from '../types/wordbook'
+
+const PART_OF_SPEECH_OPTIONS: PartOfSpeech[] = ['名詞', '動詞', '形容詞', '副詞', '前置詞']
 
 function WordList() {
   const { isAuthenticated } = useCurrentUser()
@@ -10,8 +20,19 @@ function WordList() {
   const [words, setWords] = useState<Word[]>([])
   const [meta, setMeta] = useState<PaginationMeta | null>(null)
   const [currentPage, setCurrentPage] = useState(1)
+  const [partOfSpeech, setPartOfSpeech] = useState<PartOfSpeech | ''>('')
+  const [wordbookId, setWordbookId] = useState<number | ''>('')
+  const [wordbooks, setWordbooks] = useState<Wordbook[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchWordbooks()
+      .then((response) => setWordbooks(response.data))
+      .catch(() => {
+        // 絞り込み選択肢の取得失敗は一覧表示自体を妨げないため無視する
+      })
+  }, [])
 
   useEffect(() => {
     let ignore = false
@@ -19,7 +40,7 @@ function WordList() {
     setLoading(true)
     setError(null)
 
-    fetchWords(currentPage)
+    fetchWords(currentPage, partOfSpeech || undefined, wordbookId || undefined)
       .then((response) => {
         if (ignore) return
         setWords(response.data)
@@ -37,12 +58,62 @@ function WordList() {
     return () => {
       ignore = true
     }
-  }, [currentPage])
+  }, [currentPage, partOfSpeech, wordbookId])
+
+  const handlePartOfSpeechChange = (value: string) => {
+    setPartOfSpeech(value as PartOfSpeech | '')
+    setCurrentPage(1)
+  }
+
+  const handleWordbookChange = (value: string) => {
+    setWordbookId(value ? Number(value) : '')
+    setCurrentPage(1)
+  }
 
   return (
     <div className="min-h-screen bg-white px-4 py-10">
       <div className="mx-auto max-w-3xl">
         <h1 className="mb-6 border-b-4 border-green-500 pb-2 text-3xl font-bold text-gray-900">単語一覧</h1>
+
+        <div className="mb-6 flex flex-wrap gap-4">
+          <div>
+            <label htmlFor="part_of_speech_filter" className="mb-1 block text-sm font-medium text-gray-700">
+              品詞で絞り込み
+            </label>
+            <select
+              id="part_of_speech_filter"
+              value={partOfSpeech}
+              onChange={(event) => handlePartOfSpeechChange(event.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+            >
+              <option value="">すべて</option>
+              {PART_OF_SPEECH_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label htmlFor="wordbook_filter" className="mb-1 block text-sm font-medium text-gray-700">
+              単語帳で絞り込み
+            </label>
+            <select
+              id="wordbook_filter"
+              value={wordbookId}
+              onChange={(event) => handleWordbookChange(event.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+            >
+              <option value="">すべて</option>
+              {wordbooks.map((wordbook) => (
+                <option key={wordbook.id} value={wordbook.id}>
+                  {wordbook.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
 
         {loading && <p className="text-gray-500">読み込み中...</p>}
 


### PR DESCRIPTION
## 概要

- Issue #78 として、単語一覧ページの表示件数変更と、品詞・単語帳による絞り込み機能を実装

## 主な実装

- **`backend/app/Http/Requests/WordIndexRequest.php`（新規）**：`part_of_speech`・`wordbook_id`のバリデーションを追加。既存`AdminRequest`と同じ許容値リストを踏襲し、新規Enumクラス等は追加していない
- **`backend/app/Http/Controllers/Api/WordController.php`**：`WordIndexRequest`を受け取り、絞り込み条件をUseCaseへ渡す
- **`backend/app/UseCases/Api/Word/ListWordsUseCase.php`**：1ページの表示件数を100件から30件に変更し、絞り込み条件をRepositoryへ渡す
- **`backend/app/Interfaces/WordRepositoryInterface.php` / `backend/app/Repositories/WordRepository.php`**：`when()`・`whereHas()`により品詞・単語帳での絞り込みを実装
- **`backend/app/Http/Resources/WordResource.php`**：単語帳で絞り込んだ場合、「No」「単語帳名」を絞り込んだ単語帳の情報に切り替える（単語が複数単語帳に所属するケースでの表示矛盾を回避）
- **`frontend/src/api/words.ts`**：`fetchWords`に品詞・単語帳のクエリパラメータを追加
- **`frontend/src/components/WordList.tsx`**：品詞・単語帳のプルダウン（単一選択、「すべて」を含む）を追加し、AND条件で絞り込み。絞り込み条件変更時はページを1ページ目へリセット

## Figma / 設計書との差異・補足

- レビュー指摘に基づき、単語帳一覧取得に失敗した場合は`window.alert()`でエラーを表示するよう修正（既存の`AdminWordbookSelect.tsx`の`window.confirm()`と同じ、ネイティブダイアログを使う既存パターンを踏襲）
- レビュー指摘に基づき、品詞選択時の型アサーション（`as`キャスト）を、`PART_OF_SPEECH_OPTIONS.includes()`による型ガード関数を用いたランタイム検証に置き換え

## 本PR対象外

- ページネーションUIのデザイン変更
- 表示件数をユーザーが選択できるようにする機能
- 品詞・単語帳の複数選択（チェックボックス等）
- 英単語・日本語訳などのキーワード検索
- 旧Blade用`app/UseCases/Word/ListWordsUseCase.php`の変更

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）
- `npm run lint`（oxlint）：警告・エラーなしを確認
- `npx tsc --noEmit`：型エラーなしを確認

### 受け入れ条件

- [x] 単語一覧ページで、1ページに表示される単語が最大30件になる
- [x] 単語が31件以上登録されている状態で、ページ切り替え（前へ/次へ）が正しく機能する
- [x] `現在ページ / 最終ページ`の表示が、30件区切りの正しいページ数になる
- [x] 単語一覧ページに品詞を選択するプルダウン（単一選択、「すべて」を含む）が表示され、選択すると該当品詞の単語のみ一覧に表示される
- [x] 単語一覧ページに単語帳を選択するプルダウン（単一選択、「すべて」を含む）が表示され、選択すると該当単語帳に含まれる単語のみ一覧に表示される
- [x] 品詞・単語帳の両方を選択した場合、両方の条件を満たす単語のみ表示される（AND条件）
- [x] 絞り込み条件を変更すると、表示ページが1ページ目に戻る

上記はDocker環境でテストデータ（単語35件、複数単語帳に所属する単語を含む）を用意し、APIレスポンスおよびブラウザ表示で確認済み。

### リグレッション確認

- [x] 既存機能への意図しない影響がない（フィルタ未指定時のレスポンス形式・既存の編集リンク遷移などに変更なし）

Closes #78
