### PR TITLE
feat: 単語追加成功時に成功メッセージを表示する

### DIFF
--- a/frontend/src/components/AdminWordCreate.tsx
+++ b/frontend/src/components/AdminWordCreate.tsx
@@ -15,6 +15,7 @@ function AdminWordCreate() {
 
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
+  const [submitSuccess, setSubmitSuccess] = useState<string | null>(null)
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -22,6 +23,7 @@ function AdminWordCreate() {
 
     setSubmitting(true)
     setSubmitError(null)
+    setSubmitSuccess(null)
 
     createAdminWord({
       english,
@@ -35,6 +37,7 @@ function AdminWordCreate() {
         setJapanese('')
         setPartOfSpeech('')
         setOrder('')
+        setSubmitSuccess('単語を登録しました。')
       })
       .catch(() => {
         setSubmitError('単語の登録に失敗しました。')
@@ -131,6 +134,12 @@ function AdminWordCreate() {
           {submitError && (
             <p role="alert" className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700">
               {submitError}
+            </p>
+          )}
+
+          {submitSuccess && (
+            <p role="status" className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-green-700">
+              {submitSuccess}
             </p>
           )}
 


### PR DESCRIPTION
## 概要

- Issue #77 として、単語追加フォームで送信が成功した際に、成功を示すメッセージを表示する機能を実装

## 主な実装

- **`frontend/src/components/AdminWordCreate.tsx`**：`submitSuccess`（`string | null`）stateを追加し、送信成功時に「単語を登録しました。」というメッセージを表示。既存の失敗時アラート（`role="alert"`、赤色ボックス）と同じ構造で、`role="status"`・緑色ボックスの成功メッセージを追加。送信開始時に`submitError`・`submitSuccess`の両方をクリアすることで、連続送信時に古いメッセージが残らないようにした

## Figma / 設計書との差異・補足

- 成功メッセージのaria属性は`role="status"`を採用（Issueの制約文言は失敗時アラートと同じ`role="alert"`とも解釈できたが、`/analyze`時に非緊急な報告として`role="status"`の方が適切と判断し、承認済み実装方針に明記した上で実装）

## 本PR対象外

- 単語編集・削除・単語帳作成など、他の管理系フォームへの成功メッセージ追加
- トースト通知など共通コンポーネント化

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [x] 単語追加ページで有効な入力内容を送信すると、成功したことが分かるメッセージが画面に表示される
- [x] 成功メッセージ表示後も、フォームは同じ単語帳の追加ページに留まり、入力欄はリセットされる（既存の挙動を維持）
- [x] 送信に失敗した場合は、既存の赤いエラーアラート（`submitError`）が引き続き表示される
- [x] 連続して単語を追加した場合、直前の成功メッセージが次の送信結果で正しく更新される（古いメッセージが残らない）

### リグレッション確認

- [x] 既存の入力検証（required等）・送信中の二重送信防止に影響がない

Closes #77
