### PR TITLE
feat: 単語一覧ページに英単語検索機能を追加

### DIFF
--- a/backend/app/Http/Controllers/Api/WordController.php
+++ b/backend/app/Http/Controllers/Api/WordController.php
@@ -19,6 +19,7 @@ class WordController extends Controller
 		$words = $this->listWordsUseCase->execute(
 			$request->validated('part_of_speech'),
 			$request->validated('wordbook_id'),
+			$request->validated('keyword'),
 		);
 		return WordResource::collection($words);
 	}

--- a/backend/app/Http/Requests/WordIndexRequest.php
+++ b/backend/app/Http/Requests/WordIndexRequest.php
@@ -24,6 +24,7 @@ class WordIndexRequest extends FormRequest
 		return [
 			'part_of_speech' => 'nullable|in:名詞,動詞,形容詞,副詞,前置詞',
 			'wordbook_id' => 'nullable|integer|exists:wordbooks,id',
+			'keyword' => 'nullable|string|max:255',
 		];
 	}
 }

--- a/backend/app/Interfaces/WordRepositoryInterface.php
+++ b/backend/app/Interfaces/WordRepositoryInterface.php
@@ -7,7 +7,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
 
 interface WordRepositoryInterface
 {
-	public function paginate(int $perPage, ?string $partOfSpeech = null, ?int $wordbookId = null): LengthAwarePaginator;
+	public function paginate(int $perPage, ?string $partOfSpeech = null, ?int $wordbookId = null, ?string $keyword = null): LengthAwarePaginator;
 
 	public function find(int $id): ?Word;
 

--- a/backend/app/Repositories/WordRepository.php
+++ b/backend/app/Repositories/WordRepository.php
@@ -8,11 +8,12 @@ use Illuminate\Pagination\LengthAwarePaginator;
 
 class WordRepository implements WordRepositoryInterface
 {
-	public function paginate(int $perPage, ?string $partOfSpeech = null, ?int $wordbookId = null): LengthAwarePaginator
+	public function paginate(int $perPage, ?string $partOfSpeech = null, ?int $wordbookId = null, ?string $keyword = null): LengthAwarePaginator
 	{
 		return Word::with('wordbooks')
 			->when($partOfSpeech, fn ($query) => $query->where('part_of_speech', $partOfSpeech))
 			->when($wordbookId, fn ($query) => $query->whereHas('wordbooks', fn ($q) => $q->where('wordbooks.id', $wordbookId)))
+			->when($keyword, fn ($query) => $query->where('english', 'like', '%'.$keyword.'%'))
 			->paginate($perPage);
 	}
 

--- a/backend/app/UseCases/Api/Word/ListWordsUseCase.php
+++ b/backend/app/UseCases/Api/Word/ListWordsUseCase.php
@@ -12,8 +12,8 @@ class ListWordsUseCase
 	) {
 	}
 
-	public function execute(?string $partOfSpeech, ?int $wordbookId): LengthAwarePaginator
+	public function execute(?string $partOfSpeech, ?int $wordbookId, ?string $keyword): LengthAwarePaginator
 	{
-		return $this->wordRepository->paginate(30, $partOfSpeech, $wordbookId);
+		return $this->wordRepository->paginate(30, $partOfSpeech, $wordbookId, $keyword);
 	}
 }

--- a/frontend/src/api/words.ts
+++ b/frontend/src/api/words.ts
@@ -4,11 +4,13 @@ export async function fetchWords(
   page: number,
   partOfSpeech?: PartOfSpeech,
   wordbookId?: number,
+  keyword?: string,
 ): Promise<WordListResponse> {
   const baseUrl = import.meta.env.VITE_API_BASE_URL
   const params = new URLSearchParams({ page: String(page) })
   if (partOfSpeech) params.set('part_of_speech', partOfSpeech)
   if (wordbookId) params.set('wordbook_id', String(wordbookId))
+  if (keyword) params.set('keyword', keyword)
 
   const res = await fetch(`${baseUrl}/words?${params.toString()}`)
 

--- a/frontend/src/components/WordList.tsx
+++ b/frontend/src/components/WordList.tsx
@@ -22,6 +22,8 @@ function WordList() {
   const [currentPage, setCurrentPage] = useState(1)
   const [partOfSpeech, setPartOfSpeech] = useState<PartOfSpeech | ''>('')
   const [wordbookId, setWordbookId] = useState<number | ''>('')
+  const [keyword, setKeyword] = useState('')
+  const [debouncedKeyword, setDebouncedKeyword] = useState('')
   const [wordbooks, setWordbooks] = useState<Wordbook[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -35,12 +37,22 @@ function WordList() {
   }, [])
 
   useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedKeyword(keyword)
+    }, 300)
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [keyword])
+
+  useEffect(() => {
     let ignore = false
 
     setLoading(true)
     setError(null)
 
-    fetchWords(currentPage, partOfSpeech || undefined, wordbookId || undefined)
+    fetchWords(currentPage, partOfSpeech || undefined, wordbookId || undefined, debouncedKeyword || undefined)
       .then((response) => {
         if (ignore) return
         setWords(response.data)
@@ -58,7 +70,7 @@ function WordList() {
     return () => {
       ignore = true
     }
-  }, [currentPage, partOfSpeech, wordbookId])
+  }, [currentPage, partOfSpeech, wordbookId, debouncedKeyword])
 
   const handlePartOfSpeechChange = (value: string) => {
     const isPartOfSpeech = (candidate: string): candidate is PartOfSpeech =>
@@ -72,12 +84,30 @@ function WordList() {
     setCurrentPage(1)
   }
 
+  const handleKeywordChange = (value: string) => {
+    setKeyword(value)
+    setCurrentPage(1)
+  }
+
   return (
     <div className="min-h-screen bg-white px-4 py-10">
       <div className="mx-auto max-w-3xl">
         <h1 className="mb-6 border-b-4 border-green-500 pb-2 text-3xl font-bold text-gray-900">単語一覧</h1>
 
         <div className="mb-6 flex flex-wrap gap-4">
+          <div>
+            <label htmlFor="keyword_search" className="mb-1 block text-sm font-medium text-gray-700">
+              英単語で検索
+            </label>
+            <input
+              id="keyword_search"
+              type="text"
+              value={keyword}
+              onChange={(event) => handleKeywordChange(event.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"
+            />
+          </div>
+
           <div>
             <label htmlFor="part_of_speech_filter" className="mb-1 block text-sm font-medium text-gray-700">
               品詞で絞り込み
@@ -125,7 +155,11 @@ function WordList() {
           </p>
         )}
 
-        {!loading && !error && (
+        {!loading && !error && words.length === 0 && (
+          <p className="text-gray-500">該当する単語が見つかりませんでした。</p>
+        )}
+
+        {!loading && !error && words.length > 0 && (
           <>
             <div className="overflow-hidden rounded-lg border border-gray-200 shadow-sm">
               <table className="w-full text-left text-sm">


### PR DESCRIPTION
## 概要

- Issue #81 として、単語一覧ページに英単語の検索欄を追加し、登録単語が増えても目的の単語を探しやすくする

## 主な実装

- **`backend/app/Http/Requests/WordIndexRequest.php`**：`keyword`（`nullable|string|max:255`）のバリデーションルールを、既存の`part_of_speech`・`wordbook_id`と同じ形式で追加
- **`backend/app/Interfaces/WordRepositoryInterface.php` / `backend/app/Repositories/WordRepository.php`**：`paginate`へ`keyword`引数を追加し、既存の`when`句パターンを踏襲して`english`カラムへの部分一致検索（`LIKE '%keyword%'`）をEloquentクエリビルダーで実装
- **`backend/app/UseCases/Api/Word/ListWordsUseCase.php` / `backend/app/Http/Controllers/Api/WordController.php`**：`keyword`をControllerからUseCase・Repositoryへそのまま中継
- **`frontend/src/api/words.ts`**：`fetchWords`に`keyword`クエリパラメータを追加
- **`frontend/src/components/WordList.tsx`**：品詞・単語帳フィルタと並べて検索欄（ラベル付き`input`）を追加。入力を300msデバウンスして過剰な通信を抑制し、検索条件変更時は既存フィルタと同様に1ページ目へリセット。該当0件時は「該当する単語が見つかりませんでした。」を表示

## 本PR対象外

- 管理系API（`AdminWordController`）・`AdminWordbookSelect.tsx`等：Issueは単語一覧ページ（`WordList.tsx`）に限定されており、管理専用の単語一覧ページは#67の統合により既に存在しないため
- `docs/api/public-endpoints.md`の更新：既存の`part_of_speech`・`wordbook_id`パラメータも未反映のまま運用されている実態があり、本Issueでは対応不要（別途報告済みの既知の不整合）
- 日本語での検索、前方一致・完全一致など部分一致以外の検索方式

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] 一覧ページに英単語の検索欄が表示される
- [ ] 検索欄に文字列を入力すると、英単語に部分一致する単語のみが一覧に反映される
- [ ] 検索条件に一致する単語が存在しない場合、その旨のメッセージが表示される
- [ ] 検索欄を空にすると、検索なしの通常の一覧へ戻る
- [ ] 既存の品詞・単語帳の絞り込みと検索を併用できる

### リグレッション確認

- [ ] 既存の品詞・単語帳フィルタ、ページネーションが従来通り動作する

Closes #81
