### PR TITLE
feat: 単語一覧ページのページ移動を改善

### DIFF
--- a/frontend/src/components/WordList.tsx
+++ b/frontend/src/components/WordList.tsx
@@ -216,6 +216,14 @@ function WordList() {
               <div className="mt-4 flex items-center justify-center gap-4">
                 <button
                   type="button"
+                  onClick={() => setCurrentPage(1)}
+                  disabled={meta.current_page <= 1}
+                  className="rounded-md bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
+                >
+                  最初へ
+                </button>
+                <button
+                  type="button"
                   onClick={() => setCurrentPage((page) => page - 1)}
                   disabled={meta.current_page <= 1}
                   className="rounded-md bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
@@ -232,6 +240,14 @@ function WordList() {
                   className="rounded-md bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
                 >
                   次へ
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setCurrentPage(meta.last_page)}
+                  disabled={meta.current_page >= meta.last_page}
+                  className="rounded-md bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-400"
+                >
+                  最後へ
                 </button>
               </div>
             )}


### PR DESCRIPTION
## 概要

- Issue #82 として、単語一覧ページのページ移動で離れたページへ少ない操作で移動できるよう改善

## 主な実装

- **`frontend/src/components/WordList.tsx`**：ページネーション部分に「最初へ」「最後へ」ボタンを追加。配置順は「最初へ」→「前へ」→ページ番号表示→「次へ」→「最後へ」。「最初へ」は既存「前へ」と同じ`disabled`条件（`meta.current_page <= 1`）、「最後へ」は既存「次へ」と同じ`disabled`条件（`meta.current_page >= meta.last_page`）を使用し、既存の`className`（緑背景・disabled時グレー）を再利用して見た目を統一
- ページ移動はクライアント側の`currentPage` state変更のみで完結し、既存のフェッチ用`useEffect`（`partOfSpeech`・`wordbookId`・`keyword`を依存配列に含む）がそのまま動作するため、絞り込み・検索条件は変更なしで維持される

## 本PR対象外

- ページ番号を直接指定して任意のページへ移動する機能
- バックエンドAPI・`ListWordsUseCase`・`WordRepository`：ページネーションはクライアント側の`currentPage` state変更のみで完結するため変更不要

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] 「最初のページへ」ボタンが表示され、クリックすると1ページ目が表示される
- [ ] 「最後のページへ」ボタンが表示され、クリックすると最終ページが表示される
- [ ] 既存の「前へ」「次へ」ボタンによる移動を維持する
- [ ] 現在のページ番号・総ページ数の表示を維持する
- [ ] 1ページ目では「最初のページへ」「前へ」が無効化される
- [ ] 最終ページでは「最後のページへ」「次へ」が無効化される
- [ ] ページ移動後も、適用中の絞り込み・検索条件を維持したまま一覧が正しく表示される

### リグレッション確認

- [ ] 既存の「前へ」「次へ」ボタンの挙動に変化がない

Closes #82
