### PR TITLE
feat: 単語登録後に英単語入力欄へフォーカスを戻す

### DIFF
--- a/frontend/src/components/AdminWordCreate.tsx
+++ b/frontend/src/components/AdminWordCreate.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from 'react'
+import { useRef, useState, type FormEvent } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { createAdminWord } from '../api/adminWords'
 import { PART_OF_SPEECH_BADGE_STYLES, type PartOfSpeech } from '../types/word'
@@ -16,6 +16,8 @@ function AdminWordCreate() {
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [submitSuccess, setSubmitSuccess] = useState<string | null>(null)
+
+  const englishInputRef = useRef<HTMLInputElement>(null)
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -38,6 +40,7 @@ function AdminWordCreate() {
         setPartOfSpeech('')
         setOrder('')
         setSubmitSuccess('単語を登録しました。')
+        englishInputRef.current?.focus()
       })
       .catch(() => {
         setSubmitError('単語の登録に失敗しました。')
@@ -66,6 +69,7 @@ function AdminWordCreate() {
               id="english"
               type="text"
               required
+              ref={englishInputRef}
               value={english}
               onChange={(event) => setEnglish(event.target.value)}
               className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-green-500 focus:outline-none"


### PR DESCRIPTION
## 概要

- Issue #83 として、単語登録後に英単語入力欄へ自動的にフォーカスを戻し、連続入力をしやすくする

## 主な実装

- **`frontend/src/components/AdminWordCreate.tsx`**：`english`の`input`へ`useRef<HTMLInputElement>(null)`の`ref`を追加し、登録成功時（`.then()`内、`setSubmitSuccess`と同じタイミング）に`englishInputRef.current?.focus()`を実行して英単語入力欄へフォーカスを移動する。`.catch()`（登録失敗時）ではフォーカス処理を実行しない

## 本PR対象外

- 単語編集ページ（`AdminWordEdit.tsx`）のフォーカス制御
- 画面スクロール制御：現状のページ長ではスクロールが発生しないため対応不要と判断
- フォームのバリデーション方式：既存のHTML標準`required`属性によるブラウザ標準の挙動を変更しない

## Test plan

### 自動チェック

- 未実施（テスト導入工程で別途対応）

### 受け入れ条件

- [ ] 単語を正常に登録すると、英単語の入力欄にフォーカスが移動する
- [ ] キーボード操作のみで、登録完了後すぐに次の単語を続けて入力できる
- [ ] 必須項目が未入力のまま送信した場合、問題のある入力欄にフォーカスが移動する（ブラウザ標準のバリデーション挙動を含めて確認する）

### リグレッション確認

- [ ] 既存の成功・失敗メッセージ表示、フォームリセットの挙動に変化がない

Closes #83
